### PR TITLE
Allow to pass a separator to various functions in the trackios read_c…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
+__pycache__/
 DEV/*
 trackio/supporting/*.pdf
 trackio/supporting/*.pptx
+trackio.egg-info/
 *.gpkg
 *.gpkg
 trackio/tools/stats.py

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,4 +18,6 @@ repos:
       rev: 7.0.0
       hooks:
       -   id: flake8
-          args: ["--ignore=E501,E203,W503,E722"]
+          args: 
+            - "--ignore=E501,E203,W503,E722"
+            - "--per-file-ignore=*/__init__.py:F401"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,21 @@
+repos:
+  - repo: https://github.com/hadialqattan/pycln
+    rev: v2.4.0
+    hooks:
+      - id: pycln
+        args: ["--all"]
+  - repo: https://github.com/pycqa/isort
+    rev: 5.13.2
+    hooks:
+      - id: isort
+        args: ["--profile", "black", "--line-length=79"]
+  - repo: https://github.com/psf/black
+    rev: 24.4.2
+    hooks:
+      - id: black
+        args: [--line-length=79] 
+  -   repo: https://github.com/PyCQA/flake8
+      rev: 7.0.0
+      hooks:
+      -   id: flake8
+          args: ["--ignore=E501,E203,W503,E722"]

--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,27 @@
 ################################################################################
 
-from setuptools import find_packages, setup
 import subprocess as sp
+
+from setuptools import find_packages, setup
 
 ################################################################################
 
-#manually install the wheels first
-sp.run(['pip','install','./trackio/supporting/GDAL-3.8.4-cp310-cp310-win_amd64.whl'])
-sp.run(['pip','install','./trackio/supporting/rasterio-1.3.9-cp310-cp310-win_amd64.whl'])
-sp.run(['pip','install','./trackio/supporting/inpoly-python-0.2.0.zip'])
+# manually install the wheels first
+sp.run(
+    [
+        "pip",
+        "install",
+        "./trackio/supporting/GDAL-3.8.4-cp310-cp310-win_amd64.whl",
+    ]
+)
+sp.run(
+    [
+        "pip",
+        "install",
+        "./trackio/supporting/rasterio-1.3.9-cp310-cp310-win_amd64.whl",
+    ]
+)
+sp.run(["pip", "install", "./trackio/supporting/inpoly-python-0.2.0.zip"])
 
 setup(
     name="trackio",
@@ -31,8 +44,8 @@ setup(
         "scikit-learn",
         "scikit-image",
         "kneed",
-        "dask"
-    ],    
+        "dask",
+    ],
 )
 
 ################################################################################

--- a/trackio/Agent.py
+++ b/trackio/Agent.py
@@ -1,26 +1,29 @@
 ################################################################################
 
+import warnings
+
 import numpy as np
 import pandas as pd
-from sklearn.preprocessing import StandardScaler, OneHotEncoder
-from sklearn.compose import ColumnTransformer
-from sklearn.cluster import KMeans, DBSCAN
 from kneed import KneeLocator
-from sklearn.metrics import davies_bouldin_score
-from sklearn.metrics import silhouette_score
+from sklearn.cluster import DBSCAN, KMeans
+from sklearn.compose import ColumnTransformer
+from sklearn.metrics import davies_bouldin_score, silhouette_score
+from sklearn.preprocessing import OneHotEncoder, StandardScaler
 
-import warnings
 warnings.filterwarnings("ignore", category=FutureWarning)
 
 ################################################################################
 
-must_cols = ['Time','X','Y']
+must_cols = ["Time", "X", "Y"]
+
 
 class Agent:
-    def __init__(self, 
-                 id='agent',
-                 meta={},
-                 data=pd.DataFrame({c:[] for c in must_cols})):
+    def __init__(
+        self,
+        id="agent",
+        meta={},
+        data=pd.DataFrame({c: [] for c in must_cols}),
+    ):
         """
         Initializes an Agent instance with a unique identifier, metadata, and associated dynamic data.
 
@@ -35,224 +38,253 @@ class Agent:
         data (pd.DataFrame): A pandas DataFrame consisting of, at minimum, [Time, X, Y] columns containing
                             point data.
         """
-        #set data vars      
+        # set data vars
         self._data = data
         self.append_data = []
-        # self.split_ids = []  
-        #set meta vars
+        # self.split_ids = []
+        # set meta vars
         self.meta = {}
         self.meta.update(meta)
-        self.meta['Agent ID'] = id
-        #init dicts
-        self.tracks = {}   
+        self.meta["Agent ID"] = id
+        # init dicts
+        self.tracks = {}
         self.agent_meta = {}
-        self.track_meta = {}   
-        
+        self.track_meta = {}
+
     ############################################################################
-    #ATTRIBUTES
+    # ATTRIBUTES
     ############################################################################
-    
+
     @property
     def data(self):
         if self._data is None:
             return pd.concat(self.tracks.values()).reset_index(drop=True)
         else:
             return self._data
-        
+
     ############################################################################
-    #METHODS
+    # METHODS
     ############################################################################
-        
-    def split_tracks_spatiotemporal(self, 
-                                    time, 
-                                    distance,
-                                    tracks=[],
-                                    method=0):
-        #if only specific tracks
+
+    def split_tracks_spatiotemporal(self, time, distance, tracks=[], method=0):
+        # if only specific tracks
         if len(tracks) > 0:
-            old_track_ids = [f"{self.meta['Agent ID']}_T{i}" for i in range(len(self.tracks))]
-            keep_track_ids = [tid.rsplit('_', 1)[1] for tid in old_track_ids if tid not in tracks]
+            old_track_ids = [
+                f"{self.meta['Agent ID']}_T{i}"
+                for i in range(len(self.tracks))
+            ]
+            keep_track_ids = [
+                tid.rsplit("_", 1)[1]
+                for tid in old_track_ids
+                if tid not in tracks
+            ]
             keep_tracks = [self.tracks[idx] for idx in keep_track_ids]
             for tid in keep_track_ids:
                 self.tracks.pop(tid)
-        #grab additional data for this agent group
+        # grab additional data for this agent group
         if len(self.append_data) > 0:
             data = pd.concat([self.data, *self.append_data]).copy()
             self.append_data = []
         else:
             data = self.data.copy()
         if method == 0:
-            #sort the data by time and get uniq
-            data = data.drop_duplicates(subset='Time')
-            data = data.sort_values(by='Time').reset_index(drop=True)
-            #split the data by time differences
-            time_splits = np.diff(data['Time']).astype(np.int64) * 1e-9 > time #nanoseconds to seconds
-            #split the data by distance
-            dists = np.sqrt(np.diff(data['X'])**2 + np.diff(data['Y'])**2) 
+            # sort the data by time and get uniq
+            data = data.drop_duplicates(subset="Time")
+            data = data.sort_values(by="Time").reset_index(drop=True)
+            # split the data by time differences
+            time_splits = (
+                np.diff(data["Time"]).astype(np.int64) * 1e-9 > time
+            )  # nanoseconds to seconds
+            # split the data by distance
+            dists = np.sqrt(np.diff(data["X"]) ** 2 + np.diff(data["Y"]) ** 2)
             dist_splits = dists > distance
-            #could be either or OR both need short-circuit
+            # could be either or OR both need short-circuit
             splits = time_splits | dist_splits
             split_ids = np.nonzero(splits)[0] + 1
             # self.split_ids = split_ids
-            #split into track dataframes
+            # split into track dataframes
             idxs = np.split(range(len(data)), split_ids)
         else:
-            #sort the data by time
-            data = data.sort_values(by='Time').reset_index(drop=True) 
+            # sort the data by time
+            data = data.sort_values(by="Time").reset_index(drop=True)
             idxs = [[0]]
-            #loop over the data sequentially to account for overlapping data (i.e. wrong identifier for 2+ tracks)
+            # loop over the data sequentially to account for overlapping data (i.e. wrong identifier for 2+ tracks)
             for i in range(1, len(data)):
                 new_track = True
-                #for each already established track
+                # for each already established track
                 for track_idx in idxs:
                     old_id = track_idx[-1]
-                    dt = (data.iloc[i]['Time'] - data.iloc[old_id]['Time']).total_seconds()
-                    dy = data.iloc[i]['Y'] - data.iloc[old_id]['Y'] 
-                    dx = data.iloc[i]['X'] - data.iloc[old_id]['X'] 
-                    dist = (dx**2+dy**2)**0.5
-                    #if still on this track
+                    dt = (
+                        data.iloc[i]["Time"] - data.iloc[old_id]["Time"]
+                    ).total_seconds()
+                    dy = data.iloc[i]["Y"] - data.iloc[old_id]["Y"]
+                    dx = data.iloc[i]["X"] - data.iloc[old_id]["X"]
+                    dist = (dx**2 + dy**2) ** 0.5
+                    # if still on this track
                     if dt <= time and dist <= distance:
                         track_idx.append(i)
                         new_track = False
                         break
-                #if it didn't get assigned to any existing tracks
-                if new_track:  
+                # if it didn't get assigned to any existing tracks
+                if new_track:
                     idxs.append([i])
-        #reset tracks
-        self.tracks = {}   
-        #init new track meta
+        # reset tracks
+        self.tracks = {}
+        # init new track meta
         track_meta = {}
         for i, idx in enumerate(idxs):
-            #get split track
+            # get split track
             tdf = data.iloc[idx].copy()
-            #save track data
-            self.tracks[f'T{i}'] = tdf.reset_index(drop=True)
-            track_meta[f'T{i}'] = gen_track_meta(tdf)
-            track_meta[f'T{i}']['Track ID'] = f"{self.meta['Agent ID']}_T{i}"
-        #if only specific tracks were split, re-add the old ones that weren't touched
+            # save track data
+            self.tracks[f"T{i}"] = tdf.reset_index(drop=True)
+            track_meta[f"T{i}"] = gen_track_meta(tdf)
+            track_meta[f"T{i}"]["Track ID"] = f"{self.meta['Agent ID']}_T{i}"
+        # if only specific tracks were split, re-add the old ones that weren't touched
         nstart = len(self.tracks)
         if len(tracks) > 0:
             for i in range(len(keep_tracks)):
                 j = i + nstart
-                #save track data
-                self.tracks[f'T{j}'] = keep_tracks[i]
-                track_meta[f'T{j}'] = gen_track_meta(keep_tracks[i])
-                track_meta[f'T{j}']['Track ID'] = f"{self.meta['Agent ID']}_T{j}"
-        #update the track meta
+                # save track data
+                self.tracks[f"T{j}"] = keep_tracks[i]
+                track_meta[f"T{j}"] = gen_track_meta(keep_tracks[i])
+                track_meta[f"T{j}"][
+                    "Track ID"
+                ] = f"{self.meta['Agent ID']}_T{j}"
+        # update the track meta
         self.track_meta = track_meta
-        #add the agent meta
+        # add the agent meta
         self.agent_meta = gen_agent_meta(self)
-        #delete the original data as it's now stored in tracks, don't double it
+        # delete the original data as it's now stored in tracks, don't double it
         self._data = None
-        return self  
-      
-    def split_tracks_by_data(self, 
-                             data_col,
-                             tracks=[]):
-        #if only specific tracks
+        return self
+
+    def split_tracks_by_data(self, data_col, tracks=[]):
+        # if only specific tracks
         if len(tracks) > 0:
             # old_track_ids = [f"{self.meta['Agent ID']}_T{i}" for i in range(len(self.tracks))]
-            old_track_ids = [f"{self.meta['Agent ID']}_{tid}" for tid in self.tracks.keys()]
-            keep_track_ids = [tid.rsplit('_', 1)[1] for tid in old_track_ids if tid not in tracks]
+            old_track_ids = [
+                f"{self.meta['Agent ID']}_{tid}" for tid in self.tracks.keys()
+            ]
+            keep_track_ids = [
+                tid.rsplit("_", 1)[1]
+                for tid in old_track_ids
+                if tid not in tracks
+            ]
             keep_tracks = [self.tracks[idx] for idx in keep_track_ids]
             for tid in keep_track_ids:
                 self.tracks.pop(tid)
-            #loop over tracks and split
+            # loop over tracks and split
             split_tracks = []
             for tid in self.tracks.keys():
                 track = self.tracks[tid]
-                #split the data by changes in data column
+                # split the data by changes in data column
                 splitter = track[data_col].values
                 splits = np.diff(splitter)
-                split_ids = np.nonzero(splits)[0]+1
+                split_ids = np.nonzero(splits)[0] + 1
                 idxs = np.split(range(len(track)), split_ids)
                 for idx in idxs:
-                    split_tracks.append(track.iloc[idx].copy().reset_index(drop=True))
-        #if from points
+                    split_tracks.append(
+                        track.iloc[idx].copy().reset_index(drop=True)
+                    )
+        # if from points
         else:
             split_tracks = []
-            #grab additional data for this agent group
+            # grab additional data for this agent group
             if len(self.append_data) > 0:
                 data = pd.concat([self.data, *self.append_data]).copy()
                 self.append_data = []
             else:
                 data = self.data.copy()
-            #sort by time
-            data = data.sort_values(by='Time').reset_index(drop=True)
-            #split the data by changes in data column
+            # sort by time
+            data = data.sort_values(by="Time").reset_index(drop=True)
+            # split the data by changes in data column
             splitter = data[data_col].values
             splits = np.diff(splitter)
-            split_ids = np.nonzero(splits)[0]+1
+            split_ids = np.nonzero(splits)[0] + 1
             idxs = np.split(range(len(data)), split_ids)
             for idx in idxs:
-                split_tracks.append(data.iloc[idx].copy().reset_index(drop=True))
-        #reset tracks
-        self.tracks = {}   
-        #init new track meta
+                split_tracks.append(
+                    data.iloc[idx].copy().reset_index(drop=True)
+                )
+        # reset tracks
+        self.tracks = {}
+        # init new track meta
         track_meta = {}
-        for i,tdf in enumerate(split_tracks):
-            #save track data
-            self.tracks[f'T{i}'] = tdf
-            track_meta[f'T{i}'] = gen_track_meta(tdf)
-            track_meta[f'T{i}']['Track ID'] = f"{self.meta['Agent ID']}_T{i}"
-        #if only specific tracks were split, re-add the old ones that weren't touched
+        for i, tdf in enumerate(split_tracks):
+            # save track data
+            self.tracks[f"T{i}"] = tdf
+            track_meta[f"T{i}"] = gen_track_meta(tdf)
+            track_meta[f"T{i}"]["Track ID"] = f"{self.meta['Agent ID']}_T{i}"
+        # if only specific tracks were split, re-add the old ones that weren't touched
         nstart = len(self.tracks)
         if len(tracks) > 0:
             for i in range(len(keep_tracks)):
                 j = i + nstart
-                #save track data
-                self.tracks[f'T{j}'] = keep_tracks[i]
-                track_meta[f'T{j}'] = gen_track_meta(keep_tracks[i])
-                track_meta[f'T{j}']['Track ID'] = f"{self.meta['Agent ID']}_T{j}"
-        #update the track meta
+                # save track data
+                self.tracks[f"T{j}"] = keep_tracks[i]
+                track_meta[f"T{j}"] = gen_track_meta(keep_tracks[i])
+                track_meta[f"T{j}"][
+                    "Track ID"
+                ] = f"{self.meta['Agent ID']}_T{j}"
+        # update the track meta
         self.track_meta = track_meta
-        #add the agent meta
+        # add the agent meta
         self.agent_meta = gen_agent_meta(self)
-        #delete the original data as it's now stored in tracks, don't double it
+        # delete the original data as it's now stored in tracks, don't double it
         self._data = None
-        return self 
-        
-    def split_tracks_kmeans(self,
-                            n_clusters=range(1,4),
-                            feature_cols=['X','Y'],
-                            tracks=[],
-                            return_inertia=False,
-                            optimal_method='davies-bouldin',
-                            **kwargs):        
-        #if only specific tracks
+        return self
+
+    def split_tracks_kmeans(
+        self,
+        n_clusters=range(1, 4),
+        feature_cols=["X", "Y"],
+        tracks=[],
+        return_inertia=False,
+        optimal_method="davies-bouldin",
+        **kwargs,
+    ):
+        # if only specific tracks
         if len(tracks) > 0:
-            old_track_ids = [f"{self.meta['Agent ID']}_T{i}" for i in range(len(self.tracks))]
-            keep_track_ids = [tid.rsplit('_', 1)[1] for tid in old_track_ids if tid not in tracks]
+            old_track_ids = [
+                f"{self.meta['Agent ID']}_T{i}"
+                for i in range(len(self.tracks))
+            ]
+            keep_track_ids = [
+                tid.rsplit("_", 1)[1]
+                for tid in old_track_ids
+                if tid not in tracks
+            ]
             keep_tracks = [self.tracks[idx] for idx in keep_track_ids]
             for tid in keep_track_ids:
                 self.tracks.pop(tid)
-        #grab additional data for this agent group
+        # grab additional data for this agent group
         if len(self.append_data) > 0:
             data = pd.concat([self.data, *self.append_data]).copy()
             self.append_data = []
         else:
             data = self.data.copy()
-        #make old copy
+        # make old copy
         old_data = data.dropna(subset=feature_cols)
-        old_data = old_data.sort_values(by='Time').reset_index(drop=True)
-        #reduce to features, drop nan values
+        old_data = old_data.sort_values(by="Time").reset_index(drop=True)
+        # reduce to features, drop nan values
         data = old_data[feature_cols].copy()
-        #convert time to seconds
-        if 'Time' in feature_cols:
-            data['Time'] = data['Time'].astype(np.int64) * 1e-9
-        #check if encoding is needed for non numeric columns
+        # convert time to seconds
+        if "Time" in feature_cols:
+            data["Time"] = data["Time"].astype(np.int64) * 1e-9
+        # check if encoding is needed for non numeric columns
         for col in data.columns:
             if not pd.api.types.is_numeric_dtype(data[col]):
                 # Define a transformer for the one-hot encoding
-                transformer = ColumnTransformer(transformers=[
-                    (col, OneHotEncoder(), [col])
-                ], remainder='passthrough')
-                #transform the data
+                transformer = ColumnTransformer(
+                    transformers=[(col, OneHotEncoder(), [col])],
+                    remainder="passthrough",
+                )
+                # transform the data
                 data = transformer.fit_transform(data)
-        #standardize the features
+        # standardize the features
         scaler = StandardScaler()
         data = scaler.fit_transform(data)
-        #loop over the k-values
+        # loop over the k-values
         n_clusters = sorted(n_clusters)
         clusters = []
         inertia = []
@@ -268,185 +300,213 @@ class Agent:
             db = davies_bouldin_score(data, kmeans.labels_)
             daviesbouldin.append(db)
             clusters.append(kmeans.labels_)
-            error_rows.append({'Agent ID': self.meta['Agent ID'],
-                               'n_clusters': k,
-                               'inertia': kmeans.inertia_,
-                               'davies-bouldin': db,
-                               'silhouette': s})
+            error_rows.append(
+                {
+                    "Agent ID": self.meta["Agent ID"],
+                    "n_clusters": k,
+                    "inertia": kmeans.inertia_,
+                    "davies-bouldin": db,
+                    "silhouette": s,
+                }
+            )
         if len(n_clusters) == 1:
             optimal_id = 0
         else:
-            if optimal_method == 'davies-bouldin':
+            if optimal_method == "davies-bouldin":
                 optimal_id = int(np.argmin(daviesbouldin))
-            elif optimal_method == 'silhouette':
+            elif optimal_method == "silhouette":
                 optimal_id = int(np.argmax(silhouette))
             else:
-                kneedle = KneeLocator(n_clusters,
-                            inertia, 
-                            curve='convex', 
-                            direction='decreasing')
+                kneedle = KneeLocator(
+                    n_clusters, inertia, curve="convex", direction="decreasing"
+                )
                 optimal_id = kneedle.knee
-        assert isinstance(optimal_id, int), 'could not find an optimal n_clusters value'
-        #get labels
+        assert isinstance(
+            optimal_id, int
+        ), "could not find an optimal n_clusters value"
+        # get labels
         labels = clusters[optimal_id]
         uniq_labels = np.unique(labels)
-        #reset tracks
-        self.tracks = {}   
-        #init new track meta
+        # reset tracks
+        self.tracks = {}
+        # init new track meta
         track_meta = {}
-        #loop over tracks
-        for i,label in enumerate(uniq_labels):
+        # loop over tracks
+        for i, label in enumerate(uniq_labels):
             mask = labels == label
-            #get split track
+            # get split track
             tdf = old_data.loc[mask].copy()
-            #save track data
-            self.tracks[f'T{i}'] = tdf.reset_index(drop=True)
-            track_meta[f'T{i}'] = gen_track_meta(tdf)
-            track_meta[f'T{i}']['Track ID'] = f"{self.meta['Agent ID']}_T{i}"
-        #if only specific tracks were split, re-add the old ones that weren't touched
+            # save track data
+            self.tracks[f"T{i}"] = tdf.reset_index(drop=True)
+            track_meta[f"T{i}"] = gen_track_meta(tdf)
+            track_meta[f"T{i}"]["Track ID"] = f"{self.meta['Agent ID']}_T{i}"
+        # if only specific tracks were split, re-add the old ones that weren't touched
         nstart = len(self.tracks)
         if len(tracks) > 0:
             for i in range(len(keep_tracks)):
                 j = i + nstart
-                #save track data
-                self.tracks[f'T{j}'] = keep_tracks[i]
-                track_meta[f'T{j}'] = gen_track_meta(keep_tracks[i])
-                track_meta[f'T{j}']['Track ID'] = f"{self.meta['Agent ID']}_T{j}"
-        #update the track meta
+                # save track data
+                self.tracks[f"T{j}"] = keep_tracks[i]
+                track_meta[f"T{j}"] = gen_track_meta(keep_tracks[i])
+                track_meta[f"T{j}"][
+                    "Track ID"
+                ] = f"{self.meta['Agent ID']}_T{j}"
+        # update the track meta
         self.track_meta = track_meta
-        #add the agent meta
+        # add the agent meta
         self.agent_meta = gen_agent_meta(self)
-        #delete the original data as it's now stored in tracks, don't double it
+        # delete the original data as it's now stored in tracks, don't double it
         self._data = None
         if return_inertia:
             return self, error_rows
         else:
             return self
 
-    def split_tracks_dbscan(self,
-                            feature_cols=['X','Y'],
-                            tracks=[],
-                            eps=0.5,
-                            min_samples=2,
-                            **kwargs):       
-            #if only specific tracks
-            if len(tracks) > 0:
-                old_track_ids = [f"{self.meta['Agent ID']}_T{i}" for i in range(len(self.tracks))]
-                keep_track_ids = [tid.rsplit('_',1)[1] for tid in old_track_ids if tid not in tracks]
-                keep_tracks = [self.tracks[idx] for idx in keep_track_ids]
-                for tid in keep_track_ids:
-                    self.tracks.pop(tid)
-            #grab additional data for this agent group
-            if len(self.append_data) > 0:
-                data = pd.concat([self.data, *self.append_data]).copy()
-                self.append_data = []
-            else:
-                data = self.data.copy()
-            #make old copy
-            old_data = data.dropna(subset=feature_cols)
-            old_data = old_data.sort_values(by='Time').reset_index(drop=True)
-            #reduce to features, drop nan values
-            data = old_data[feature_cols].copy()
-            #convert time to seconds
-            if 'Time' in feature_cols:
-                data['Time'] = data['Time'].astype(np.int64) * 1e-9
-            #check if encoding is needed for non numeric columns
-            for col in data.columns:
-                if not pd.api.types.is_numeric_dtype(data[col]):
-                    # Define a transformer for the one-hot encoding
-                    transformer = ColumnTransformer(transformers=[
-                        (col, OneHotEncoder(), [col])
-                    ], remainder='passthrough')
-                    #transform the data
-                    data = transformer.fit_transform(data)
-            #standardize the features
-            scaler = StandardScaler()
-            data = scaler.fit_transform(data)
-            #cluster the data
-            dbscan = DBSCAN(eps=eps, min_samples=min_samples, **kwargs)
-            #get labels
-            labels = dbscan.fit(data).labels_
-            uniq_labels = np.unique(labels)
-            #reset tracks
-            self.tracks = {}   
-            #init new track meta
-            track_meta = {}
-            #loop over tracks
-            for i,label in enumerate(uniq_labels):
-                mask = labels == label
-                #get split track
-                tdf = old_data.loc[mask].copy()
-                #save track data
-                self.tracks[f'T{i}'] = tdf.reset_index(drop=True)
-                track_meta[f'T{i}'] = gen_track_meta(tdf)
-                track_meta[f'T{i}']['Track ID'] = f"{self.meta['Agent ID']}_T{i}"
-            #if only specific tracks were split, re-add the old ones that weren't touched
-            nstart = len(self.tracks)
-            if len(tracks) > 0:
-                for i in range(len(keep_tracks)):
-                    j = i + nstart
-                    #save track data
-                    self.tracks[f'T{j}'] = keep_tracks[i]
-                    track_meta[f'T{j}'] = gen_track_meta(keep_tracks[i])
-                    track_meta[f'T{j}']['Track ID'] = f"{self.meta['Agent ID']}_T{j}"
-            #update the track meta
-            self.track_meta = track_meta
-            #add the agent meta
-            self.agent_meta = gen_agent_meta(self)
-            #delete the original data as it's now stored in tracks, don't double it
-            self._data = None
-            return self
+    def split_tracks_dbscan(
+        self,
+        feature_cols=["X", "Y"],
+        tracks=[],
+        eps=0.5,
+        min_samples=2,
+        **kwargs,
+    ):
+        # if only specific tracks
+        if len(tracks) > 0:
+            old_track_ids = [
+                f"{self.meta['Agent ID']}_T{i}"
+                for i in range(len(self.tracks))
+            ]
+            keep_track_ids = [
+                tid.rsplit("_", 1)[1]
+                for tid in old_track_ids
+                if tid not in tracks
+            ]
+            keep_tracks = [self.tracks[idx] for idx in keep_track_ids]
+            for tid in keep_track_ids:
+                self.tracks.pop(tid)
+        # grab additional data for this agent group
+        if len(self.append_data) > 0:
+            data = pd.concat([self.data, *self.append_data]).copy()
+            self.append_data = []
+        else:
+            data = self.data.copy()
+        # make old copy
+        old_data = data.dropna(subset=feature_cols)
+        old_data = old_data.sort_values(by="Time").reset_index(drop=True)
+        # reduce to features, drop nan values
+        data = old_data[feature_cols].copy()
+        # convert time to seconds
+        if "Time" in feature_cols:
+            data["Time"] = data["Time"].astype(np.int64) * 1e-9
+        # check if encoding is needed for non numeric columns
+        for col in data.columns:
+            if not pd.api.types.is_numeric_dtype(data[col]):
+                # Define a transformer for the one-hot encoding
+                transformer = ColumnTransformer(
+                    transformers=[(col, OneHotEncoder(), [col])],
+                    remainder="passthrough",
+                )
+                # transform the data
+                data = transformer.fit_transform(data)
+        # standardize the features
+        scaler = StandardScaler()
+        data = scaler.fit_transform(data)
+        # cluster the data
+        dbscan = DBSCAN(eps=eps, min_samples=min_samples, **kwargs)
+        # get labels
+        labels = dbscan.fit(data).labels_
+        uniq_labels = np.unique(labels)
+        # reset tracks
+        self.tracks = {}
+        # init new track meta
+        track_meta = {}
+        # loop over tracks
+        for i, label in enumerate(uniq_labels):
+            mask = labels == label
+            # get split track
+            tdf = old_data.loc[mask].copy()
+            # save track data
+            self.tracks[f"T{i}"] = tdf.reset_index(drop=True)
+            track_meta[f"T{i}"] = gen_track_meta(tdf)
+            track_meta[f"T{i}"]["Track ID"] = f"{self.meta['Agent ID']}_T{i}"
+        # if only specific tracks were split, re-add the old ones that weren't touched
+        nstart = len(self.tracks)
+        if len(tracks) > 0:
+            for i in range(len(keep_tracks)):
+                j = i + nstart
+                # save track data
+                self.tracks[f"T{j}"] = keep_tracks[i]
+                track_meta[f"T{j}"] = gen_track_meta(keep_tracks[i])
+                track_meta[f"T{j}"][
+                    "Track ID"
+                ] = f"{self.meta['Agent ID']}_T{j}"
+        # update the track meta
+        self.track_meta = track_meta
+        # add the agent meta
+        self.agent_meta = gen_agent_meta(self)
+        # delete the original data as it's now stored in tracks, don't double it
+        self._data = None
+        return self
+
 
 ################################################################################
 
-#generate the metadata
+
+# generate the metadata
 def gen_track_meta(tdf):
     first = tdf.iloc[0]
     last = tdf.iloc[-1]
-    t0 = first['Time']
-    t1 = last['Time']
-    dts = np.diff(tdf['Time']).astype("timedelta64[s]").astype(np.int64)
-    dxs = (np.diff(tdf['X'])**2 + np.diff(tdf['Y'])**2)**0.5
+    t0 = first["Time"]
+    t1 = last["Time"]
+    dts = np.diff(tdf["Time"]).astype("timedelta64[s]").astype(np.int64)
+    dxs = (np.diff(tdf["X"]) ** 2 + np.diff(tdf["Y"]) ** 2) ** 0.5
     tmeta = {
-        "Track Length": ((tdf['X'].diff()**2 + tdf['Y'].diff()**2)**0.5).sum(),
+        "Track Length": (
+            (tdf["X"].diff() ** 2 + tdf["Y"].diff() ** 2) ** 0.5
+        ).sum(),
         "npoints": len(tdf),
         "Start Time": t0,
         "End Time": t1,
-        "Duration": int((t1-t0).total_seconds()),
+        "Duration": int((t1 - t0).total_seconds()),
         "Year": int(t1.year),
         "Month": int(t1.month),
-        "Xmin": tdf['X'].min(),
-        "Xmax": tdf['X'].max(),
-        "Ymin": tdf['Y'].min(),
-        "Ymax": tdf['Y'].max(),
-        "Xstart": first['X'],
-        "Ystart": first['Y'],
-        "Xend": last['X'],
-        "Yend": last['Y'],
-        "Effective Distance": ((first['X'] - last['X']) ** 2 + (first['Y'] - last['Y']) ** 2) ** 0.5,
+        "Xmin": tdf["X"].min(),
+        "Xmax": tdf["X"].max(),
+        "Ymin": tdf["Y"].min(),
+        "Ymax": tdf["Y"].max(),
+        "Xstart": first["X"],
+        "Ystart": first["Y"],
+        "Xend": last["X"],
+        "Yend": last["Y"],
+        "Effective Distance": (
+            (first["X"] - last["X"]) ** 2 + (first["Y"] - last["Y"]) ** 2
+        )
+        ** 0.5,
         "Min Temporal Resolution": np.nanmin(dts) if len(dts) > 0 else 0,
         "Mean Temporal Resolution": np.nanmean(dts) if len(dts) > 0 else 0,
         "Max Temporal Resolution": np.nanmax(dts) if len(dts) > 0 else 0,
-        "Min Spatial Resolution": np.nanmin(dxs) if len(dxs) > 0  else 0,
-        "Mean Spatial Resolution": np.nanmean(dxs) if len(dxs) > 0  else 0,
-        "Max Spatial Resolution": np.nanmax(dxs) if len(dxs) > 0  else 0,
-        **tdf.filter(like='Code').any(axis=0).to_dict()
-        }
-    tmeta['Sinuosity'] = tmeta['Track Length']/tmeta['Effective Distance']
+        "Min Spatial Resolution": np.nanmin(dxs) if len(dxs) > 0 else 0,
+        "Mean Spatial Resolution": np.nanmean(dxs) if len(dxs) > 0 else 0,
+        "Max Spatial Resolution": np.nanmax(dxs) if len(dxs) > 0 else 0,
+        **tdf.filter(like="Code").any(axis=0).to_dict(),
+    }
+    tmeta["Sinuosity"] = tmeta["Track Length"] / tmeta["Effective Distance"]
     return tmeta
 
+
 def gen_agent_meta(self):
-    #grab some basic metadata
+    # grab some basic metadata
     vdf = self.data
-    vmeta = {**self.meta,
+    vmeta = {
+        **self.meta,
         "npoints": len(self.data),
         "ntracks": len(self.tracks),
-        "Xmin": vdf['X'].min(),
-        "Xmax": vdf['X'].max(),
-        "Ymin": vdf['Y'].min(),
-        "Ymax": vdf['Y'].max(),
-        "Start Time": vdf['Time'].min(),
-        "End Time": vdf['Time'].max(),
-        **vdf.filter(like='Code').any(axis=0).to_dict()
-        }
+        "Xmin": vdf["X"].min(),
+        "Xmax": vdf["X"].max(),
+        "Ymin": vdf["Y"].min(),
+        "Ymax": vdf["Y"].max(),
+        "Start Time": vdf["Time"].min(),
+        "End Time": vdf["Time"].max(),
+        **vdf.filter(like="Code").any(axis=0).to_dict(),
+    }
     return vmeta

--- a/trackio/Agent.py
+++ b/trackio/Agent.py
@@ -151,7 +151,8 @@ class Agent:
                              tracks=[]):
         #if only specific tracks
         if len(tracks) > 0:
-            old_track_ids = [f"{self.meta['Agent ID']}_T{i}" for i in range(len(self.tracks))]
+            # old_track_ids = [f"{self.meta['Agent ID']}_T{i}" for i in range(len(self.tracks))]
+            old_track_ids = [f"{self.meta['Agent ID']}_{tid}" for tid in self.tracks.keys()]
             keep_track_ids = [tid.rsplit('_', 1)[1] for tid in old_track_ids if tid not in tracks]
             keep_tracks = [self.tracks[idx] for idx in keep_track_ids]
             for tid in keep_track_ids:

--- a/trackio/Dataset.py
+++ b/trackio/Dataset.py
@@ -1,36 +1,32 @@
 ################################################################################
 
-from . import (utils, 
-               process, 
-               geometry, 
-               classify, 
-               io,
-               maps)
-
-from .Agent import (gen_track_meta, 
-                    gen_agent_meta)
-
-from copy import deepcopy
-import re
-import pyproj
-import geopandas as gp
 import glob
 import multiprocessing as mp
-import numpy as np
 import os
-import pandas as pd
-from pyproj import CRS, Transformer
-from shapely.geometry import (box, 
-                              LineString, 
-                              MultiLineString, 
-                              Polygon, 
-                              MultiPolygon,
-                              Point)
-import rasterio as rio
+import re
+from copy import deepcopy
+
 import dask.bag as db
+import geopandas as gp
+import numpy as np
+import pandas as pd
+import pyproj
+import rasterio as rio
 from inpoly import inpoly2
+from pyproj import CRS, Transformer
 from scipy.interpolate import RegularGridInterpolator
+from shapely.geometry import (
+    LineString,
+    MultiLineString,
+    MultiPolygon,
+    Point,
+    Polygon,
+    box,
+)
 from tqdm import tqdm
+
+from . import classify, geometry, io, maps, process, utils
+from .Agent import gen_agent_meta, gen_track_meta
 
 GREEN = "\033[92m"
 ENDC = "\033[0m"
@@ -39,23 +35,26 @@ YELLOW = "\033[93m"
 
 ################################################################################
 
-#hardcoded file names
-agent_database = 'agent.db'
-track_database = 'track.db'
-dataset_meta = 'dataset.db'
+# hardcoded file names
+agent_database = "agent.db"
+track_database = "track.db"
+dataset_meta = "dataset.db"
+
 
 class Dataset:
-    
-    def __init__(self,
-                data_path='./data',
-                raw_files=None,
-                raw_df=None,
-                raw_gdf=None,
-                data_files=None,
-                meta={}):
+
+    def __init__(
+        self,
+        data_path="./data",
+        raw_files=None,
+        raw_df=None,
+        raw_gdf=None,
+        data_files=None,
+        meta={},
+    ):
         """
         Initializes a Dataset object.
-        
+
         Args:
             data_path (str): Defaults to './data'.
             raw_files (list, optional): List of raw data files. Defaults to None.
@@ -66,54 +65,61 @@ class Dataset:
         Returns:
             Dataset: Initialized Dataset object.
         """
-        #set attributes
+        # set attributes
         self.data_path = os.path.abspath(data_path)
         self.meta = self.check_meta(meta)
-        #set raw df
-        msg = 'raw_df must be None or pd.DataFrame'
+        # set raw df
+        msg = "raw_df must be None or pd.DataFrame"
         assert isinstance(raw_df, (type(None), pd.DataFrame)), msg
         self.raw_df = raw_df
-        #set raw gdf
-        msg = 'raw_gdf must be None or gp.GeoDataFrame'
+        # set raw gdf
+        msg = "raw_gdf must be None or gp.GeoDataFrame"
         assert isinstance(raw_gdf, (type(None), gp.GeoDataFrame)), msg
         self.raw_gdf = raw_gdf
-        #grab all processed files if None provided
+        # grab all processed files if None provided
         data_files = self._check_files(data_files)
-        #set file status
-        self.status = self._init_status(raw_files, 
-                                       data_files)
-    
+        # set file status
+        self.status = self._init_status(raw_files, data_files)
+
     def __repr__(self):
         submeta = self.meta.copy()
-        submeta.pop('Static Data')
-        submeta.pop('Dynamic Data')
-        m = [str(key)+': '+str(val)+'\n' for key,val in submeta.items()]
-        type_repr = f'Type:\n    {self.__class__}\n'
-        status_repr1 = f'Status:\n'
-        status_repr2 = f"    {len(self.status['Unprocessed'])} Unprocessed CSV Files\n"
-        status_repr3 = f"    {len(self.status['Processed'])} Processed CSV Files\n"
-        status_repr4 = f"    {len(self.status['Unsplit'])} Unsplit Agent Files\n"
+        submeta.pop("Static Data")
+        submeta.pop("Dynamic Data")
+        m = [str(key) + ": " + str(val) + "\n" for key, val in submeta.items()]
+        type_repr = f"Type:\n    {self.__class__}\n"
+        status_repr1 = "Status:\n"
+        status_repr2 = (
+            f"    {len(self.status['Unprocessed'])} Unprocessed CSV Files\n"
+        )
+        status_repr3 = (
+            f"    {len(self.status['Processed'])} Processed CSV Files\n"
+        )
+        status_repr4 = (
+            f"    {len(self.status['Unsplit'])} Unsplit Agent Files\n"
+        )
         status_repr5 = f"    {len(self.status['Split'])} Split Agent Files\n"
         data_repr1 = f"Static Data Fields:\n    {self.meta['Static Data']}\n"
         data_repr2 = f"Dynamic Data Fields:\n    {self.meta['Dynamic Data']}\n"
         meta_repr = f"Metadata:\n    {'    '.join(m)}"
-        path_repr = f'Data Path:\n    {os.path.abspath(self.data_path)}'
-        return (type_repr + 
-                status_repr1 + 
-                status_repr2 + 
-                status_repr3 + 
-                status_repr4 + 
-                status_repr5 + 
-                data_repr1 + 
-                data_repr2 + 
-                meta_repr + 
-                path_repr)
-        
+        path_repr = f"Data Path:\n    {os.path.abspath(self.data_path)}"
+        return (
+            type_repr
+            + status_repr1
+            + status_repr2
+            + status_repr3
+            + status_repr4
+            + status_repr5
+            + data_repr1
+            + data_repr2
+            + meta_repr
+            + path_repr
+        )
+
     ############################################################################
-    #ATTRIBUTES
+    # ATTRIBUTES
     ############################################################################
-    
-    #agent database
+
+    # agent database
     @property
     def agents(self):
         """
@@ -121,12 +127,16 @@ class Dataset:
         Use this to efficiently query agents.
         """
         try:
-            return utils.read_pkl(f'{self.data_path}/{agent_database}')
+            return utils.read_pkl(f"{self.data_path}/{agent_database}")
         except FileNotFoundError:
-            msg = RED + f"{self.data_path}/{agent_database} not found, run self.refresh_meta() first" + ENDC
+            msg = (
+                RED
+                + f"{self.data_path}/{agent_database} not found, run self.refresh_meta() first"
+                + ENDC
+            )
             print(msg)
-       
-    #track database
+
+    # track database
     @property
     def tracks(self):
         """
@@ -134,106 +144,116 @@ class Dataset:
         Use this to efficiently query tracks.
         """
         try:
-            return utils.read_pkl(f'{self.data_path}/{track_database}')
+            return utils.read_pkl(f"{self.data_path}/{track_database}")
         except FileNotFoundError:
-            msg = RED + f"{self.data_path}/{track_database} not found, run self.refresh_meta() first..." + ENDC
+            msg = (
+                RED
+                + f"{self.data_path}/{track_database} not found, run self.refresh_meta() first..."
+                + ENDC
+            )
             print(msg)
-    
-    #file mapper for each agent/track
+
+    # file mapper for each agent/track
     @property
     def _file_mapper(self):
-        #get the files and make mapper
-        unsplit = self.status['Unsplit']
-        split = self.status['Split']
-        mapper = {'Agents':{},
-                  'Tracks':{}}
-        #loop over unsplit (agent) files
-        for file in unsplit+split:
-            if file.endswith('.points'):
-                aid = os.path.basename(file).split('_processor')[0]
+        # get the files and make mapper
+        unsplit = self.status["Unsplit"]
+        split = self.status["Split"]
+        mapper = {"Agents": {}, "Tracks": {}}
+        # loop over unsplit (agent) files
+        for file in unsplit + split:
+            if file.endswith(".points"):
+                aid = os.path.basename(file).split("_processor")[0]
             else:
-                aid = os.path.basename(file).split('.tracks')[0]
-            if aid not in mapper['Agents'].keys():
-                mapper['Agents'][aid] = [os.path.abspath(file)]
+                aid = os.path.basename(file).split(".tracks")[0]
+            if aid not in mapper["Agents"].keys():
+                mapper["Agents"][aid] = [os.path.abspath(file)]
             else:
-                mapper['Agents'][aid].append(os.path.abspath(file))
-        #loop over split (track) files
+                mapper["Agents"][aid].append(os.path.abspath(file))
+        # loop over split (track) files
         for file in split:
-            aid = os.path.basename(file).split('.tracks')[0]
-            mapper['Tracks'][aid] = os.path.abspath(file)
+            aid = os.path.basename(file).split(".tracks")[0]
+            mapper["Tracks"][aid] = os.path.abspath(file)
         return mapper
-    
+
     ############################################################################
-    #METHODS
+    # METHODS
     ############################################################################
-   
+
     def _check_files(self, data_files):
-        #if None is passed
+        # if None is passed
         if data_files is None:
-            data_files = (glob.glob(f'{self.data_path}/*.tracks')+
-                         glob.glob(f'{self.data_path}/*.points'))
-        #otherwise use the list of files
+            data_files = glob.glob(f"{self.data_path}/*.tracks") + glob.glob(
+                f"{self.data_path}/*.points"
+            )
+        # otherwise use the list of files
         else:
             pass
-        #return abspaths
+        # return abspaths
         return list(map(os.path.abspath, data_files))
 
     def _init_status(self, raw, data):
-        #make a dictionary
-        status = {'Processed':[],
-                  'Unprocessed':[],
-                  'Split':[],
-                  'Unsplit':[]}
-        #add raw files
+        # make a dictionary
+        status = {
+            "Processed": [],
+            "Unprocessed": [],
+            "Split": [],
+            "Unsplit": [],
+        }
+        # add raw files
         if raw is not None:
-            status['Unprocessed'].extend(set(raw))
-        #add data files
+            status["Unprocessed"].extend(set(raw))
+        # add data files
         if data is not None:
             data = set(data)
-            #add pkl files, check for points vs tracks in file name
+            # add pkl files, check for points vs tracks in file name
             for p in data:
-                if p.endswith('.tracks'):
-                    status['Split'].append(p)
-                elif p.endswith('.points'):
-                    status['Unsplit'].append(p) 
+                if p.endswith(".tracks"):
+                    status["Split"].append(p)
+                elif p.endswith(".points"):
+                    status["Unsplit"].append(p)
         return status
 
     def _refresh_status(self):
-        #refresh file status after processing raw files
+        # refresh file status after processing raw files
         status = self._init_status(None, self._check_files(None))
-        return status    
-    
+        return status
+
     def _get_files_tracks_to_process(self, agents, tracks):
-        #get the files to process
+        # get the files to process
         all_files = self._file_mapper
         pkl_files = []
-        #based on agent ids
+        # based on agent ids
         if agents is not None:
             for agent in agents:
-                pkl_files.extend(all_files['Agents'][agent])
+                pkl_files.extend(all_files["Agents"][agent])
                 tracks = None
-        #based on track ids
+        # based on track ids
         elif tracks is not None:
             for track in tracks:
-                pkl_files.append(all_files['Tracks'][track.rsplit('_', 1)[0]])
-        #assuming all data
+                pkl_files.append(all_files["Tracks"][track.rsplit("_", 1)[0]])
+        # assuming all data
         else:
-            pkl_files = self.status['Split'].copy() + self.status['Unsplit'].copy()
+            pkl_files = (
+                self.status["Split"].copy() + self.status["Unsplit"].copy()
+            )
             tracks = None
-        #group them by agent id
-        df = pd.DataFrame({'files':pkl_files, 'track': tracks})
-        g = df['files'].tolist()
+        # group them by agent id
+        df = pd.DataFrame({"files": pkl_files, "track": tracks})
+        g = df["files"].tolist()
         g = [os.path.splitext(f)[0] for f in g]
-        for i,_g in enumerate(g):
-            replace = re.search('_processor[0-9]*', _g)
+        for i, _g in enumerate(g):
+            replace = re.search("_processor[0-9]*", _g)
             if replace:
-                g[i] = _g.replace(replace.group(), '')
-        df['grouper'] = g
-        grouped = df.groupby('grouper')[['files','track']].agg(list)
-        grouped['files'] = grouped['files'].apply(np.unique)
-        grouped['track'] = grouped['track'].apply(lambda x: np.unique(pd.Series(x).dropna()))
-        #return files and track ids corresponding to files
-        return grouped['files'].tolist(), grouped['track'].tolist()
+                g[i] = _g.replace(replace.group(), "")
+        df["grouper"] = g
+        grouped = df.groupby("grouper")[["files", "track"]].agg(list)
+        grouped["files"] = grouped["files"].apply(np.unique)
+        grouped["track"] = grouped["track"].apply(
+            lambda x: np.unique(pd.Series(x).dropna())
+        )
+        # return files and track ids corresponding to files
+        return grouped["files"].tolist(), grouped["track"].tolist()
 
     def _set_out_path(self, out_path):
         if out_path is None:
@@ -242,36 +262,38 @@ class Dataset:
             if not os.path.isdir(out_path):
                 os.mkdir(out_path)
         return out_path
-    
+
     def _update_meta(self, out_path, meta):
-        #if written to data_pth, update self.meta
+        # if written to data_pth, update self.meta
         if out_path == self.data_path:
             self.meta = meta
             out = self
-        #if written elsewhere, export the meta to there
+        # if written elsewhere, export the meta to there
         else:
-            #export meta
-            utils.save_pkl(f'{out_path}/{dataset_meta}', meta)
-            #replace the output
+            # export meta
+            utils.save_pkl(f"{out_path}/{dataset_meta}", meta)
+            # replace the output
             out = Dataset(data_path=out_path)
         return out
 
     ############################################################################
-    #PREPROCESSING
+    # PREPROCESSING
     ############################################################################
 
-    def group_points(self, 
-                     col_mapper={},
-                     meta_cols=[],
-                     data_cols=['Time','X','Y'],
-                     data_mappers={},
-                     groupby='Unique_ID',
-                     chunksize=1e6,
-                     continued=False,
-                     prefix='agent',
-                     ncores=1,
-                     sep=',',
-                     desc='Grouping points'):
+    def group_points(
+        self,
+        col_mapper={},
+        meta_cols=[],
+        data_cols=["Time", "X", "Y"],
+        data_mappers={},
+        groupby="Unique_ID",
+        chunksize=1e6,
+        continued=False,
+        prefix="agent",
+        ncores=1,
+        sep=",",
+        desc="Grouping points",
+    ):
         """
         Groups all points in Dataset based on groupby column(s) to isolate
         the points belonging to each unique agent in the raw data. Grouped
@@ -299,9 +321,9 @@ class Dataset:
         Returns:
             self: Returns the original Dataset instance.
         """
-        #create folder if doesn't exist
-        #if does, prompt user to delete, or pass continued kwarg
-        #this prevents accidentally corrupting/overwriting data
+        # create folder if doesn't exist
+        # if does, prompt user to delete, or pass continued kwarg
+        # this prevents accidentally corrupting/overwriting data
         out_path = os.path.abspath(self.data_path)
         if continued:
             pass
@@ -309,73 +331,75 @@ class Dataset:
             if not os.path.exists(out_path):
                 os.mkdir(out_path)
             else:
-                raise Exception(f'self.data_path already exists, '\
-                                 'delete or pass continue=True to resume '\
-                                 'processing in this folder...')
-        #get the list of raw files
-        raw_files = self.status['Unprocessed'].copy()
-        #setup partials for function
-        partials = (groupby,
-                    chunksize,
-                    out_path,
-                    col_mapper,
-                    meta_cols,
-                    data_cols,
-                    data_mappers,
-                    prefix,
-                    sep)
-        #if any raw files
+                raise Exception(
+                    "self.data_path already exists, "
+                    "delete or pass continue=True to resume "
+                    "processing in this folder..."
+                )
+        # get the list of raw files
+        raw_files = self.status["Unprocessed"].copy()
+        # setup partials for function
+        partials = (
+            groupby,
+            chunksize,
+            out_path,
+            col_mapper,
+            meta_cols,
+            data_cols,
+            data_mappers,
+            prefix,
+            sep,
+        )
+        # if any raw files
         if len(raw_files) > 0:
-            #process in parallel
-            utils.pool_caller(process.group_points, 
-                              partials, 
-                              raw_files, 
-                              desc, 
-                              ncores)
-        #check if raw dataframe passed
+            # process in parallel
+            utils.pool_caller(
+                process.group_points, partials, raw_files, desc, ncores
+            )
+        # check if raw dataframe passed
         if self.raw_df is not None:
-            #split into chunks
-            chunk_idxs = utils.split_list(list(range(len(self.raw_df))), 
-                                          round(len(self.raw_df)/ncores))
+            # split into chunks
+            chunk_idxs = utils.split_list(
+                list(range(len(self.raw_df))), round(len(self.raw_df) / ncores)
+            )
             chunks = [self.raw_df.iloc[idx] for idx in chunk_idxs]
-            #process in parallel
-            utils.pool_caller(process.group_points, 
-                              partials, 
-                              chunks, 
-                              desc,
-                              ncores)
-            #erase the df
+            # process in parallel
+            utils.pool_caller(
+                process.group_points, partials, chunks, desc, ncores
+            )
+            # erase the df
             self.raw_df = None
-        #check if raw geodataframe passed
+        # check if raw geodataframe passed
         if self.raw_gdf is not None:
-            #split into chunks
+            # split into chunks
             raw_df = utils.gdf_to_df(self.raw_gdf)
-            chunk_idxs = utils.split_list(list(range(len(raw_df))), 
-                                          round(len(raw_df)/ncores))
+            chunk_idxs = utils.split_list(
+                list(range(len(raw_df))), round(len(raw_df) / ncores)
+            )
             chunks = [raw_df.iloc[idx] for idx in chunk_idxs]
-            #process in parallel
-            utils.pool_caller(process.group_points, 
-                              partials, 
-                              chunks, 
-                              desc, 
-                              ncores)
-            #erase the gdf
+            # process in parallel
+            utils.pool_caller(
+                process.group_points, partials, chunks, desc, ncores
+            )
+            # erase the gdf
             self.raw_gdf = None
-        #refresh the status
+        # refresh the status
         self.status = self._refresh_status()
-        self.status['Unprocessed'] = []
-        self.status['Processed'].extend(raw_files)
+        self.status["Unprocessed"] = []
+        self.status["Processed"].extend(raw_files)
         return self
 
-    def split_tracks_spatiotemporal(self,
-                                    agents=None,
-                                    tracks=None,
-                                    time=3600 * 12, #seconds, 12hrs
-                                    distance=0.5, #same units as DataSet, default = 0.5deg = 55km
-                                    ncores=1, 
-                                    out_path=None,
-                                    remove=True,
-                                    desc='Splitting tracks using spatiotemporal threshold'): 
+    def split_tracks_spatiotemporal(
+        self,
+        agents=None,
+        tracks=None,
+        time=3600 * 12,  # seconds, 12hrs
+        distance=0.5,  # same units as DataSet, default = 0.5deg = 55km
+        ncores=1,
+        out_path=None,
+        remove=True,
+        desc="Splitting tracks using spatiotemporal threshold",
+    ):
         """
         Perform standard spatiotemporal split on points to generate tracks. This algorithm
         simply looks at gaps between adjacent points, if the gap in time OR distance is exceeded
@@ -387,7 +411,7 @@ class Dataset:
         If you pass remove=True, it will delete *.points files as they are split and saved into *.tracks files.
 
         If you pass a directory for the out_path kwarg, the *.tracks files will be saved to this directory,
-        and self.data_path will be changed as well. If you pass None, it simply saves the *.tracks files 
+        and self.data_path will be changed as well. If you pass None, it simply saves the *.tracks files
         in the original self.data_path location.
 
         Args:
@@ -403,40 +427,46 @@ class Dataset:
         Returns:
             self: The Dataset instance.
         """
-        #set out path
+        # set out path
         out_path = self._set_out_path(out_path)
-        #get the files to process
-        pkl_groups = list(zip(*self._get_files_tracks_to_process(agents, tracks)))
-        #process tracks in parallel
-        utils.pool_caller(process.split_tracks_spatiotemporal,
-                          (time, distance, out_path, remove, 0), #split method
-                          pkl_groups,
-                          desc, 
-                          ncores)
-        #refresh the status
+        # get the files to process
+        pkl_groups = list(
+            zip(*self._get_files_tracks_to_process(agents, tracks))
+        )
+        # process tracks in parallel
+        utils.pool_caller(
+            process.split_tracks_spatiotemporal,
+            (time, distance, out_path, remove, 0),  # split method
+            pkl_groups,
+            desc,
+            ncores,
+        )
+        # refresh the status
         self.status = self._refresh_status()
-        #update meta
+        # update meta
         self = self._update_meta(out_path, self.meta)
         return self
-    
-    def split_tracks_by_data(self,
-                             agents=None,
-                             tracks=None,
-                             data_col='Status',
-                             ncores=1, 
-                             out_path=None,
-                             remove=True,
-                             desc='Splitting tracks by changes in data column'): 
+
+    def split_tracks_by_data(
+        self,
+        agents=None,
+        tracks=None,
+        data_col="Status",
+        ncores=1,
+        out_path=None,
+        remove=True,
+        desc="Splitting tracks by changes in data column",
+    ):
         """
         Splits tracks based on changes in a specified data column. This method is useful for segmenting
         tracks when a particular attribute changes, for example, when an agent's code column changes. This
-        function works by splitting tracks when the value in the specified data column changes, e.g. from 
+        function works by splitting tracks when the value in the specified data column changes, e.g. from
         True to False, from 0 to 1, etc.
 
         If you pass remove=True, it will delete *.points files as they are split and saved into *.tracks files.
 
         If you pass a directory for the out_path kwarg, the *.tracks files will be saved to this directory,
-        and self.data_path will be changed as well. If you pass None, it simply saves the *.tracks files 
+        and self.data_path will be changed as well. If you pass None, it simply saves the *.tracks files
         in the original self.data_path location.
 
         Args:
@@ -451,32 +481,38 @@ class Dataset:
         Returns:
             self: The Dataset instance.
         """
-        #set out path
+        # set out path
         out_path = self._set_out_path(out_path)
-        #get the files to process
-        pkl_groups = list(zip(*self._get_files_tracks_to_process(agents, tracks)))
+        # get the files to process
+        pkl_groups = list(
+            zip(*self._get_files_tracks_to_process(agents, tracks))
+        )
 
-        #process tracks in parallel
-        utils.pool_caller(process.split_tracks_by_data,
-                          (data_col, out_path, remove),
-                          pkl_groups,
-                          desc, 
-                          ncores)
-        #refresh the status
+        # process tracks in parallel
+        utils.pool_caller(
+            process.split_tracks_by_data,
+            (data_col, out_path, remove),
+            pkl_groups,
+            desc,
+            ncores,
+        )
+        # refresh the status
         self.status = self._refresh_status()
-        #update meta
+        # update meta
         self = self._update_meta(out_path, self.meta)
         return self
-    
-    def split_overlapping_tracks_spatiotemporal(self,
-                                    agents=None,
-                                    tracks=None,
-                                    time=3600 * 12, #seconds, 12hrs
-                                    distance=0.5, #same units as DataSet, default = 0.5deg = 55km
-                                    ncores=1, 
-                                    out_path=None,
-                                    remove=True,
-                                    desc='Splitting overlapping tracks using spatiotemporal threshold'): 
+
+    def split_overlapping_tracks_spatiotemporal(
+        self,
+        agents=None,
+        tracks=None,
+        time=3600 * 12,  # seconds, 12hrs
+        distance=0.5,  # same units as DataSet, default = 0.5deg = 55km
+        ncores=1,
+        out_path=None,
+        remove=True,
+        desc="Splitting overlapping tracks using spatiotemporal threshold",
+    ):
         """
         Perform standard spatiotemporal split on points to generate tracks. This algorithm
         differs from split_tracks_spatiotemporal but uses the same inputs. This can sometimes
@@ -495,7 +531,7 @@ class Dataset:
         If you pass remove=True, it will delete *.points files as they are split and saved into *.tracks files.
 
         If you pass a directory for the out_path kwarg, the *.tracks files will be saved to this directory,
-        and self.data_path will be changed as well. If you pass None, it simply saves the *.tracks files 
+        and self.data_path will be changed as well. If you pass None, it simply saves the *.tracks files
         in the original self.data_path location.
 
         Args:
@@ -511,34 +547,40 @@ class Dataset:
         Returns:
             self: The Dataset instance.
         """
-        #set out path
+        # set out path
         out_path = self._set_out_path(out_path)
-        #get the files to process
-        pkl_groups = list(zip(*self._get_files_tracks_to_process(agents, tracks)))
-        #process tracks in parallel
-        utils.pool_caller(process.split_tracks_spatiotemporal,
-                          (time, distance, out_path, remove, 1), #split method
-                          pkl_groups,
-                          desc, 
-                          ncores)
-        #refresh the status
+        # get the files to process
+        pkl_groups = list(
+            zip(*self._get_files_tracks_to_process(agents, tracks))
+        )
+        # process tracks in parallel
+        utils.pool_caller(
+            process.split_tracks_spatiotemporal,
+            (time, distance, out_path, remove, 1),  # split method
+            pkl_groups,
+            desc,
+            ncores,
+        )
+        # refresh the status
         self.status = self._refresh_status()
-        #update meta
+        # update meta
         self = self._update_meta(out_path, self.meta)
         return self
-    
-    def split_tracks_kmeans(self,
-                            agents=None,
-                            tracks=None,
-                            n_clusters=range(10),
-                            feature_cols=['X','Y'],
-                            out_path=None,
-                            ncores=1,
-                            return_error=False,
-                            remove=True,
-                            desc='Using KMeans clustering to split tracks',
-                            optimal_method='davies-bouldin',
-                            **kwargs):
+
+    def split_tracks_kmeans(
+        self,
+        agents=None,
+        tracks=None,
+        n_clusters=range(10),
+        feature_cols=["X", "Y"],
+        out_path=None,
+        ncores=1,
+        return_error=False,
+        remove=True,
+        desc="Using KMeans clustering to split tracks",
+        optimal_method="davies-bouldin",
+        **kwargs,
+    ):
         """
         Splits tracks using KMeans clustering based on specified features. This method attempts
         to identify natural groupings of data points within tracks based on the specified features
@@ -556,7 +598,7 @@ class Dataset:
         If you pass remove=True, it will delete *.points files as they are split and saved into *.tracks files.
 
         If you pass a directory for the out_path kwarg, the *.tracks files will be saved to this directory,
-        and self.data_path will be changed as well. If you pass None, it simply saves the *.tracks files 
+        and self.data_path will be changed as well. If you pass None, it simply saves the *.tracks files
         in the original self.data_path location.
 
         Args:
@@ -577,57 +619,70 @@ class Dataset:
             - self: The Dataset instance, if return_error is False.
             - tuple: (self, error), where error is a DataFrame of errors for each cluster number in n_clusters, if return_error is True.
         """
-        #set out path
+        # set out path
         out_path = self._set_out_path(out_path)
-        #make sure k is int or list of ints
-        msg = 'n_clusters must be int, list of ints, or range'
-        assert (isinstance(n_clusters, int) or 
-                (isinstance(n_clusters, list) and all([isinstance(_k, int) for _k in n_clusters])) or
-                isinstance(n_clusters, range)), msg
-        #turn to list for function
+        # make sure k is int or list of ints
+        msg = "n_clusters must be int, list of ints, or range"
+        assert (
+            isinstance(n_clusters, int)
+            or (
+                isinstance(n_clusters, list)
+                and all([isinstance(_k, int) for _k in n_clusters])
+            )
+            or isinstance(n_clusters, range)
+        ), msg
+        # turn to list for function
         if isinstance(n_clusters, int):
             n_clusters = [n_clusters]
         else:
             n_clusters = sorted(n_clusters)
-        #assert more than 2 clusters
-        msg = 'n_clusters must be 2 or greater'
+        # assert more than 2 clusters
+        msg = "n_clusters must be 2 or greater"
         assert min(n_clusters) > 1, msg
-        #get the files to process
-        pkl_groups = list(zip(*self._get_files_tracks_to_process(agents, tracks)))
-        #process clustering in parallel
-        error = utils.pool_caller(process.split_tracks_kmeans,
-                                  (n_clusters, 
-                                   feature_cols, 
-                                   out_path, 
-                                   return_error, 
-                                   remove, 
-                                   optimal_method,
-                                   kwargs),
-                                  pkl_groups,
-                                  desc,
-                                  ncores)
-        #refresh the status
+        # get the files to process
+        pkl_groups = list(
+            zip(*self._get_files_tracks_to_process(agents, tracks))
+        )
+        # process clustering in parallel
+        error = utils.pool_caller(
+            process.split_tracks_kmeans,
+            (
+                n_clusters,
+                feature_cols,
+                out_path,
+                return_error,
+                remove,
+                optimal_method,
+                kwargs,
+            ),
+            pkl_groups,
+            desc,
+            ncores,
+        )
+        # refresh the status
         self.status = self._refresh_status()
-        #update meta
+        # update meta
         self = self._update_meta(out_path, self.meta)
-        #return
+        # return
         if return_error:
             error = utils.flatten(error)
             return self, pd.DataFrame(error)
         else:
             return self
-    
-    def split_tracks_dbscan(self,
-                            agents=None,
-                            tracks=None,
-                            feature_cols=['X','Y'],
-                            out_path=None,
-                            ncores=1,
-                            remove=True,
-                            eps=0.5,
-                            min_samples=2,
-                            desc='Using DBSCAN clustering to split tracks',
-                            **kwargs):
+
+    def split_tracks_dbscan(
+        self,
+        agents=None,
+        tracks=None,
+        feature_cols=["X", "Y"],
+        out_path=None,
+        ncores=1,
+        remove=True,
+        eps=0.5,
+        min_samples=2,
+        desc="Using DBSCAN clustering to split tracks",
+        **kwargs,
+    ):
         """
         Splits tracks using the DBSCAN clustering algorithm based on specified feature columns.
         This method groups points into clusters based on their density, allowing for the identification
@@ -641,7 +696,7 @@ class Dataset:
         If you pass remove=True, it will delete *.points files as they are split and saved into *.tracks files.
 
         If you pass a directory for the out_path kwarg, the *.tracks files will be saved to this directory,
-        and self.data_path will be changed as well. If you pass None, it simply saves the *.tracks files 
+        and self.data_path will be changed as well. If you pass None, it simply saves the *.tracks files
         in the original self.data_path location.
 
         Args:
@@ -659,34 +714,35 @@ class Dataset:
         Returns:
             self: The Dataset instance.
         """
-        #set out path
+        # set out path
         out_path = self._set_out_path(out_path)
-        #get the files to process
-        pkl_groups = list(zip(*self._get_files_tracks_to_process(agents, tracks)))
-        #process clustering in parallel
-        utils.pool_caller(process.split_tracks_dbscan,
-                            (feature_cols, 
-                            out_path, 
-                            remove, 
-                            eps, 
-                            min_samples,
-                            kwargs),
-                            pkl_groups,
-                            desc,
-                            ncores)
-        #refresh the status
+        # get the files to process
+        pkl_groups = list(
+            zip(*self._get_files_tracks_to_process(agents, tracks))
+        )
+        # process clustering in parallel
+        utils.pool_caller(
+            process.split_tracks_dbscan,
+            (feature_cols, out_path, remove, eps, min_samples, kwargs),
+            pkl_groups,
+            desc,
+            ncores,
+        )
+        # refresh the status
         self.status = self._refresh_status()
-        #update meta
+        # update meta
         self = self._update_meta(out_path, self.meta)
         return self
-    
-    def repair_tracks_spatiotemporal(self, 
-                                     agents=None,
-                                     time=3600 * 12, #seconds, 12hrs
-                                     distance=0.5, #same units as DataSet, default = 0.5deg = 55km
-                                     ncores=1, 
-                                     out_path=None,
-                                     desc='Repairing tracks using spatiotemporal threshold'):
+
+    def repair_tracks_spatiotemporal(
+        self,
+        agents=None,
+        time=3600 * 12,  # seconds, 12hrs
+        distance=0.5,  # same units as DataSet, default = 0.5deg = 55km
+        ncores=1,
+        out_path=None,
+        desc="Repairing tracks using spatiotemporal threshold",
+    ):
         """
         Repairs tracks by connecting disjoint segments based on spatiotemporal thresholds.
         This method is intended to identify and bridge gaps within tracks that are shorter than
@@ -699,7 +755,7 @@ class Dataset:
         erroneously split tracks.
 
         If you pass a directory for the out_path kwarg, the *.tracks files will be saved to this directory,
-        and self.data_path will be changed as well. If you pass None, it simply saves the *.tracks files 
+        and self.data_path will be changed as well. If you pass None, it simply saves the *.tracks files
         in the original self.data_path location.
 
         Args:
@@ -713,29 +769,28 @@ class Dataset:
         Returns:
             self: The Dataset instance.
         """
-        #set out path
+        # set out path
         out_path = self._set_out_path(out_path)
-        #get the files to process
+        # get the files to process
         pkl_files, _ = self._get_files_tracks_to_process(agents, None)
         pkl_files = utils.flatten(pkl_files)
-        #process repairs in parallel
-        utils.pool_caller(process.repair_tracks_spatiotemporal,
-                          (time, 
-                           distance, 
-                           out_path),
-                          pkl_files,
-                          desc,
-                          ncores)
-        #refresh the status
+        # process repairs in parallel
+        utils.pool_caller(
+            process.repair_tracks_spatiotemporal,
+            (time, distance, out_path),
+            pkl_files,
+            desc,
+            ncores,
+        )
+        # refresh the status
         self.status = self._refresh_status()
-        #update meta
+        # update meta
         self = self._update_meta(out_path, self.meta)
         return self
-    
-    def remove_agents(self,
-                      agents=None,
-                      desc='Removing agents from Dataset',
-                      ncores=1):
+
+    def remove_agents(
+        self, agents=None, desc="Removing agents from Dataset", ncores=1
+    ):
         """
         Removes specified agents from the Dataset. This operation is designed to
         selectively remove agents based on their identifiers, facilitating data management
@@ -751,21 +806,19 @@ class Dataset:
         """
         pkl_files, _ = self._get_files_tracks_to_process(agents, None)
         pkl_files = utils.flatten(pkl_files)
-        #remove the files in parallel
-        utils.pool_caller(os.remove, 
-                          (), 
-                          pkl_files, 
-                          desc, 
-                          ncores)
-        #refresh the status
+        # remove the files in parallel
+        utils.pool_caller(os.remove, (), pkl_files, desc, ncores)
+        # refresh the status
         self.status = self._refresh_status()
-        return self            
-    
-    def remove_tracks(self,
-                      tracks=None,
-                      ncores=1,
-                      out_path=None,
-                      desc='Removing tracks from Dataset'):
+        return self
+
+    def remove_tracks(
+        self,
+        tracks=None,
+        ncores=1,
+        out_path=None,
+        desc="Removing tracks from Dataset",
+    ):
         """
         Removes specified tracks from the Dataset. This operation is designed to
         selectively remove tracks based on their identifiers, facilitating data management
@@ -779,27 +832,26 @@ class Dataset:
         Returns:
             self: The Dataset instance.
         """
-        #set out path
+        # set out path
         out_path = self._set_out_path(out_path)
-        #get the files to process
-        pkl_groups = list(zip(*self._get_files_tracks_to_process(None, tracks)))
-        utils.pool_caller(process.remove_tracks,
-                          (out_path,),
-                          pkl_groups,
-                          desc,
-                          ncores)
-        #refresh the status
+        # get the files to process
+        pkl_groups = list(
+            zip(*self._get_files_tracks_to_process(None, tracks))
+        )
+        utils.pool_caller(
+            process.remove_tracks, (out_path,), pkl_groups, desc, ncores
+        )
+        # refresh the status
         self.status = self._refresh_status()
-        #update meta
+        # update meta
         self = self._update_meta(out_path, self.meta)
         return self
-        
-    def get_track_splits(self, 
-                         agents=None,
-                         ncores=1,
-                         desc='Getting track split data'):
+
+    def get_track_splits(
+        self, agents=None, ncores=1, desc="Getting track split data"
+    ):
         """
-        Retrieves data related to the gaps between tracks. This function is useful for analyzing 
+        Retrieves data related to the gaps between tracks. This function is useful for analyzing
         how tracks have been divided spatiotemporally, and potentially isolating a list of
         tracks to rejoin.
 
@@ -812,41 +864,40 @@ class Dataset:
         Returns:
             DataFrame: A pandas DataFrame containing the track split data.
         """
-        #get the files to process
+        # get the files to process
         pkl_files, _ = self._get_files_tracks_to_process(agents, None)
         pkl_files = utils.flatten(pkl_files)
-        #loop through each, process to split tracks
-        rows = utils.pool_caller(process.get_track_gaps,
-                                 (),
-                                 pkl_files,
-                                 desc,
-                                 ncores)
+        # loop through each, process to split tracks
+        rows = utils.pool_caller(
+            process.get_track_gaps, (), pkl_files, desc, ncores
+        )
         rows = utils.flatten(rows)
         df = pd.DataFrame(rows)
-        df['Connect'] = False
+        df["Connect"] = False
         return df
 
     ############################################################################
-    #METADATA
+    # METADATA
     ############################################################################
 
     def check_meta(self, meta):
-        #try to fetch the meta if already exists
+        # try to fetch the meta if already exists
         if meta == {}:
             try:
-                meta = utils.read_pkl(f'{self.data_path}/{dataset_meta}')
+                meta = utils.read_pkl(f"{self.data_path}/{dataset_meta}")
             except FileNotFoundError:
-                msg = f'\nNo {dataset_meta} found in {self.data_path}. '\
-                       '\nUsing default units/crs. '\
-                       '\nEdit self.meta and then run self.refresh_meta to update.\n'
+                msg = (
+                    f"\nNo {dataset_meta} found in {self.data_path}. "
+                    "\nUsing default units/crs. "
+                    "\nEdit self.meta and then run self.refresh_meta to update.\n"
+                )
                 print(msg)
                 meta = utils.std_meta()
         return meta
 
-    def refresh_meta(self, 
-                     agents_only=False, 
-                     ncores=1,
-                     desc='Refreshing metadata'):
+    def refresh_meta(
+        self, agents_only=False, ncores=1, desc="Refreshing metadata"
+    ):
         """
         Refreshes the metadata associated with the Dataset. This involves updating the
         dataset.db, agent.db, and track.db files stored in the Dataset.data_path folder.
@@ -855,9 +906,9 @@ class Dataset:
 
         You only need to do this if you want the .db files to be updated, which is only
         necessary if you need an updated output for Dataset.meta, Dataset.agents, or Dataset.tracks.
-        
+
         Passing agents_only=True should only be used when points have been grouped into *.points files
-        but have not yet been split into tracks. This will provide metadata on the agents that 
+        but have not yet been split into tracks. This will provide metadata on the agents that
         can be useful for doing categorical splitting. For example, splitting AIS data for cargo vessels
         differently than fishing vessels.
 
@@ -871,57 +922,57 @@ class Dataset:
         Returns:
             self: The Dataset instance.
         """
-        #process metadata in parallel
-        iterable = self.status['Unsplit'] + self.status['Split']
-        #assert there's even data
-        assert len(iterable) > 0, f'No point or track files in {self.data_path}'
-        meta_metacols_datacols = utils.pool_caller(_refresh_meta,
-                                                    (agents_only,),
-                                                    iterable,
-                                                    desc,
-                                                    ncores)
+        # process metadata in parallel
+        iterable = self.status["Unsplit"] + self.status["Split"]
+        # assert there's even data
+        assert (
+            len(iterable) > 0
+        ), f"No point or track files in {self.data_path}"
+        meta_metacols_datacols = utils.pool_caller(
+            _refresh_meta, (agents_only,), iterable, desc, ncores
+        )
         _meta = [m[0] for m in meta_metacols_datacols]
-        _meta_cols = np.unique(utils.flatten([m[1] for 
-                                              m in meta_metacols_datacols])).tolist()
-        _data_cols = np.unique(utils.flatten([m[2] for 
-                                              m in meta_metacols_datacols])).tolist()
-        #combine into 1 dict
+        _meta_cols = np.unique(
+            utils.flatten([m[1] for m in meta_metacols_datacols])
+        ).tolist()
+        _data_cols = np.unique(
+            utils.flatten([m[2] for m in meta_metacols_datacols])
+        ).tolist()
+        # combine into 1 dict
         meta = {}
         for m in _meta:
             meta |= m
-        #get and write agent database
-        agents = _meta_to_agents(meta, self.meta['CRS'])
-        #convert datetimes
-        agents['Start Time'] = pd.to_datetime(agents['Start Time'])
-        agents['End Time'] = pd.to_datetime(agents['End Time'])
-        #save agent database
-        utils.save_pkl(f'{self.data_path}/{agent_database}', agents)
-        #if there's track data
-        if len(self.status['Split']) > 0:
-            #get and write track database
-            tracks = _meta_to_tracks(meta, self.meta['CRS'])
-            #convert the datetimes
-            tracks['Start Time'] = pd.to_datetime(tracks['Start Time'])
-            tracks['End Time'] = pd.to_datetime(tracks['End Time'])
-            #save track database
-            utils.save_pkl(f'{self.data_path}/{track_database}', tracks)
+        # get and write agent database
+        agents = _meta_to_agents(meta, self.meta["CRS"])
+        # convert datetimes
+        agents["Start Time"] = pd.to_datetime(agents["Start Time"])
+        agents["End Time"] = pd.to_datetime(agents["End Time"])
+        # save agent database
+        utils.save_pkl(f"{self.data_path}/{agent_database}", agents)
+        # if there's track data
+        if len(self.status["Split"]) > 0:
+            # get and write track database
+            tracks = _meta_to_tracks(meta, self.meta["CRS"])
+            # convert the datetimes
+            tracks["Start Time"] = pd.to_datetime(tracks["Start Time"])
+            tracks["End Time"] = pd.to_datetime(tracks["End Time"])
+            # save track database
+            utils.save_pkl(f"{self.data_path}/{track_database}", tracks)
         else:
-            #if only unsplit point files
-            print(f'No split track files found, skipping {track_database}')
-        #save the latest dataset meta
+            # if only unsplit point files
+            print(f"No split track files found, skipping {track_database}")
+        # save the latest dataset meta
         meta = self.meta
-        meta['Static Data'] = _meta_cols
-        meta['Dynamic Data'] = _data_cols
-        utils.save_pkl(f'{self.data_path}/{dataset_meta}', meta)
-        #return
-        print(f'New meta/databases saved to {self.data_path}')
+        meta["Static Data"] = _meta_cols
+        meta["Dynamic Data"] = _data_cols
+        utils.save_pkl(f"{self.data_path}/{dataset_meta}", meta)
+        # return
+        print(f"New meta/databases saved to {self.data_path}")
         return self
 
-    def make_meta_mapper(self,
-                         meta_cols,
-                         agents=None,
-                         ncores=1,
-                         desc='Making meta mappers'):
+    def make_meta_mapper(
+        self, meta_cols, agents=None, ncores=1, desc="Making meta mappers"
+    ):
         """
         Creates a metadata mapper dictionary based on the meta_cols provided. This mapper can be used to
         translate or map metadata values, potentially simplifying data analysis and manipulation
@@ -938,42 +989,42 @@ class Dataset:
             dict: A dictionary where keys are the names of the data columns specified in `meta_cols`, and
                 the values are the created data mappers.
         """
-        #must be list of data columns
-        msg = 'meta_cols must be a list of meta columns'
+        # must be list of data columns
+        msg = "meta_cols must be a list of meta columns"
         assert isinstance(meta_cols, list) and len(meta_cols) > 0, msg
-        #get the files to process
+        # get the files to process
         pkl_files, _ = self._get_files_tracks_to_process(agents, None)
         pkl_files = utils.flatten(pkl_files)
-        #read data from agents in parallel
-        _out =  utils.pool_caller(maps.make_meta_mapper,
-                                 (meta_cols,),
-                                 pkl_files,
-                                 desc,
-                                 ncores)
-        #reduce to unique dictionary
+        # read data from agents in parallel
+        _out = utils.pool_caller(
+            maps.make_meta_mapper, (meta_cols,), pkl_files, desc, ncores
+        )
+        # reduce to unique dictionary
         out = utils.flatten_dict_unique(_out)
-        #turn into blank mapper
-        mappers = [{k:None for k in out[key]} for key in meta_cols]
-        #if single mapper just return it
+        # turn into blank mapper
+        mappers = [{k: None for k in out[key]} for key in meta_cols]
+        # if single mapper just return it
         if len(mappers) == 1:
             return mappers[0]
-        #otherwise nested dict
+        # otherwise nested dict
         else:
             return dict(zip(meta_cols, mappers))
 
-    def drop_meta(self, 
-                  meta_cols,
-                  agents=None,
-                  out_path=None,
-                  ncores=1,
-                  desc='Dropping meta from agents'):
+    def drop_meta(
+        self,
+        meta_cols,
+        agents=None,
+        out_path=None,
+        ncores=1,
+        desc="Dropping meta from agents",
+    ):
         """
         Drops specified metadata from agents. This function allows for selective removal of metadata
         associated with certain agents, potentially for data cleaning, or to reduce
         dataset size.
 
         If you pass a directory for the out_path kwarg, the *.tracks files will be saved to this directory,
-        and self.data_path will be changed as well. If you pass None, it simply saves the *.tracks files 
+        and self.data_path will be changed as well. If you pass None, it simply saves the *.tracks files
         in the original self.data_path location.
 
         Args:
@@ -988,34 +1039,38 @@ class Dataset:
         Returns:
             self: The Dataset instance.
         """
-        #must be list of data columns
-        msg = 'meta_cols must be a list of meta columns'
+        # must be list of data columns
+        msg = "meta_cols must be a list of meta columns"
         assert isinstance(meta_cols, list) and len(meta_cols) > 0, msg
-        #set out path
+        # set out path
         out_path = self._set_out_path(out_path)
-        #get the files to process
+        # get the files to process
         pkl_files, _ = self._get_files_tracks_to_process(agents, None)
         pkl_files = utils.flatten(pkl_files)
-        #delete data from agents in parallel
-        utils.pool_caller(maps.drop_agent_meta,
-                        (meta_cols, out_path),
-                        pkl_files,
-                        desc,
-                        ncores)
-        #update meta
+        # delete data from agents in parallel
+        utils.pool_caller(
+            maps.drop_agent_meta,
+            (meta_cols, out_path),
+            pkl_files,
+            desc,
+            ncores,
+        )
+        # update meta
         self = self._update_meta(out_path, self.meta)
         return self
-        
-    def map_meta(self,
-                meta_cols, 
-                out_meta_cols,
-                meta_mappers,
-                agents=None,
-                out_path=None,
-                ncores=1,
-                drop=False,
-                fill=None,
-                desc='Mapping metadata to agent'):
+
+    def map_meta(
+        self,
+        meta_cols,
+        out_meta_cols,
+        meta_mappers,
+        agents=None,
+        out_path=None,
+        ncores=1,
+        drop=False,
+        fill=None,
+        desc="Mapping metadata to agent",
+    ):
         """
         Applies a mapping function to transform metadata of selected agents. This can be used to
         normalize, categorize, or otherwise process metadata fields for consistency, analysis,
@@ -1023,7 +1078,7 @@ class Dataset:
         how input metadata values are mapped to output values.
 
         If you pass a directory for the out_path kwarg, the *.tracks files will be saved to this directory,
-        and self.data_path will be changed as well. If you pass None, it simply saves the *.tracks files 
+        and self.data_path will be changed as well. If you pass None, it simply saves the *.tracks files
         in the original self.data_path location.
 
         Args:
@@ -1044,32 +1099,36 @@ class Dataset:
         Returns:
             self: The Dataset instance.
         """
-        #must be list and proper dict
-        msg = f'meta_mappers missing one or all of keys: {meta_cols}'
+        # must be list and proper dict
+        msg = f"meta_mappers missing one or all of keys: {meta_cols}"
         assert all([i in meta_mappers.keys() for i in meta_cols]), msg
-        msg = 'out_meta_cols is not the same length as meta_cols'
+        msg = "out_meta_cols is not the same length as meta_cols"
         assert len(meta_cols) == len(out_meta_cols), msg
-        #set out path
+        # set out path
         out_path = self._set_out_path(out_path)
-        #get the files to process
+        # get the files to process
         pkl_files, _ = self._get_files_tracks_to_process(agents, None)
         pkl_files = utils.flatten(pkl_files)
-        #map metadata to agents in parallel
-        utils.pool_caller(maps.map_agent_meta,
-                          (meta_cols, out_meta_cols, meta_mappers, out_path, drop, fill),
-                          pkl_files,
-                          desc,
-                          ncores)
-        #update meta
+        # map metadata to agents in parallel
+        utils.pool_caller(
+            maps.map_agent_meta,
+            (meta_cols, out_meta_cols, meta_mappers, out_path, drop, fill),
+            pkl_files,
+            desc,
+            ncores,
+        )
+        # update meta
         self = self._update_meta(out_path, self.meta)
         return self
-    
-    def make_data_mapper(self,
-                         data_cols,
-                         agents=None,
-                         tracks=None,
-                         ncores=1,
-                         desc='Making data mappers'):
+
+    def make_data_mapper(
+        self,
+        data_cols,
+        agents=None,
+        tracks=None,
+        ncores=1,
+        desc="Making data mappers",
+    ):
         """
         Creates a mapping for data columns to facilitate data transformation. This function
         can be particularly useful for preparing data for machine learning models, data visualization,
@@ -1092,40 +1151,42 @@ class Dataset:
             dict: A dictionary where keys are the names of the data columns specified in `data_cols`, and
                 the values are the created data mappers.
         """
-        #must be list of data columns
-        msg = 'data_cols must be a list of data columns'
+        # must be list of data columns
+        msg = "data_cols must be a list of data columns"
         assert isinstance(data_cols, list) and len(data_cols) > 0, msg
-        #get the files to process
-        pkl_groups = list(zip(*self._get_files_tracks_to_process(agents, tracks)))
-        #read data from agents in parallel
-        _out =  utils.pool_caller(maps.make_data_mapper,
-                                 (data_cols,),
-                                 pkl_groups,
-                                 desc,
-                                 ncores)
-        #reduce to unique dictionary
+        # get the files to process
+        pkl_groups = list(
+            zip(*self._get_files_tracks_to_process(agents, tracks))
+        )
+        # read data from agents in parallel
+        _out = utils.pool_caller(
+            maps.make_data_mapper, (data_cols,), pkl_groups, desc, ncores
+        )
+        # reduce to unique dictionary
         out = utils.flatten_dict_unique(_out)
-        #turn into blank mapper
-        mappers = [{k:None for k in out[key]} for key in data_cols]
-        #if single mapper just return it
+        # turn into blank mapper
+        mappers = [{k: None for k in out[key]} for key in data_cols]
+        # if single mapper just return it
         if len(mappers) == 1:
             return mappers[0]
         else:
             return dict(zip(data_cols, mappers))
-    
-    def drop_data(self, 
-                  data_cols,
-                  agents=None,
-                  out_path=None,
-                  ncores=1,
-                  desc='Dropping dynamic data from agents'):
+
+    def drop_data(
+        self,
+        data_cols,
+        agents=None,
+        out_path=None,
+        ncores=1,
+        desc="Dropping dynamic data from agents",
+    ):
         """
         Drops specified dynamic data from agents. This function allows for selective removal of data
         associated with certain agents, potentially for data cleaning, or to reduce
         dataset size.
 
         If you pass a directory for the out_path kwarg, the *.tracks files will be saved to this directory,
-        and self.data_path will be changed as well. If you pass None, it simply saves the *.tracks files 
+        and self.data_path will be changed as well. If you pass None, it simply saves the *.tracks files
         in the original self.data_path location.
 
         Args:
@@ -1140,35 +1201,39 @@ class Dataset:
         Returns:
             self: The Dataset instance.
         """
-        #must be list of data columns
-        msg = 'data_cols must be a list of data columns'
+        # must be list of data columns
+        msg = "data_cols must be a list of data columns"
         assert isinstance(data_cols, list) and len(data_cols) > 0, msg
-        #set out path
+        # set out path
         out_path = self._set_out_path(out_path)
-        #get the files to process
+        # get the files to process
         pkl_files, _ = self._get_files_tracks_to_process(agents, None)
         pkl_files = utils.flatten(pkl_files)
-        #delete data from agents in parallel
-        utils.pool_caller(maps.drop_agent_data,
-                        (data_cols, out_path),
-                        pkl_files,
-                        desc,
-                        ncores)
-        #update meta
+        # delete data from agents in parallel
+        utils.pool_caller(
+            maps.drop_agent_data,
+            (data_cols, out_path),
+            pkl_files,
+            desc,
+            ncores,
+        )
+        # update meta
         self = self._update_meta(out_path, self.meta)
         return self
-    
-    def map_data(self,
-                data_cols=[],
-                out_data_cols=[],
-                data_mappers={},
-                agents=None,
-                tracks=None,
-                out_path=None,
-                ncores=1,
-                drop=False,
-                fill=None,
-                desc='Mapping agent dynamic data'):
+
+    def map_data(
+        self,
+        data_cols=[],
+        out_data_cols=[],
+        data_mappers={},
+        agents=None,
+        tracks=None,
+        out_path=None,
+        ncores=1,
+        drop=False,
+        fill=None,
+        desc="Mapping agent dynamic data",
+    ):
         """
         Applies a mapping function to transform dynamic data of selected agents/tracks. This can be used to
         normalize, categorize, or otherwise process data fields for consistency, analysis,
@@ -1176,7 +1241,7 @@ class Dataset:
         how input data values are mapped to output values.
 
         If you pass a directory for the out_path kwarg, the *.tracks files will be saved to this directory,
-        and self.data_path will be changed as well. If you pass None, it simply saves the *.tracks files 
+        and self.data_path will be changed as well. If you pass None, it simply saves the *.tracks files
         in the original self.data_path location.
 
         Args:
@@ -1196,35 +1261,41 @@ class Dataset:
         Returns:
             self: The Dataset instance.
         """
-        #must be list and proper dict
-        msg = f'data_mappers missing one or all of keys: {data_cols}'
+        # must be list and proper dict
+        msg = f"data_mappers missing one or all of keys: {data_cols}"
         assert all([i in data_mappers.keys() for i in data_cols]), msg
-        msg = 'out_data_cols is not the same length as data_cols'
+        msg = "out_data_cols is not the same length as data_cols"
         assert len(data_cols) == len(out_data_cols), msg
-        #set out path
+        # set out path
         out_path = self._set_out_path(out_path)
-        #get the files to process
-        pkl_groups = list(zip(*self._get_files_tracks_to_process(agents, tracks)))
-        #map agent data in parallel
-        utils.pool_caller(maps.map_agent_data,
-                          (data_cols, out_data_cols, data_mappers, out_path, drop, fill),
-                          pkl_groups,
-                          desc,
-                          ncores)
-        #update meta
+        # get the files to process
+        pkl_groups = list(
+            zip(*self._get_files_tracks_to_process(agents, tracks))
+        )
+        # map agent data in parallel
+        utils.pool_caller(
+            maps.map_agent_data,
+            (data_cols, out_data_cols, data_mappers, out_path, drop, fill),
+            pkl_groups,
+            desc,
+            ncores,
+        )
+        # update meta
         self = self._update_meta(out_path, self.meta)
         return self
 
-    def map_data_to_codes(self,
-                          data_cols,
-                          data_mappers,
-                          agents=None,
-                          tracks=None,
-                          out_path=None,
-                          ncores=1,
-                          drop=False,
-                          fill=-1,
-                          desc='Mapping agent dynamic data to coded boolean arrays'):
+    def map_data_to_codes(
+        self,
+        data_cols,
+        data_mappers,
+        agents=None,
+        tracks=None,
+        out_path=None,
+        ncores=1,
+        drop=False,
+        fill=-1,
+        desc="Mapping agent dynamic data to coded boolean arrays",
+    ):
         """
         Applies a mapping function to transform dynamic data of selected agents/tracks into boolean "Code"
         columns.
@@ -1235,13 +1306,13 @@ class Dataset:
 
         Each boolean column will be called "Code{i}" where i corresponds to one of the unique integers
         in the dictionary values.
-          
+
         This can be used to encode information into boolean code columns that will be available
         in the Dataset.agents and Dataset.tracks attributes, which could make for faster and more
         efficient querying.
 
         If you pass a directory for the out_path kwarg, the *.tracks files will be saved to this directory,
-        and self.data_path will be changed as well. If you pass None, it simply saves the *.tracks files 
+        and self.data_path will be changed as well. If you pass None, it simply saves the *.tracks files
         in the original self.data_path location.
 
         Args:
@@ -1260,36 +1331,40 @@ class Dataset:
         Returns:
             self: The Dataset instance.
         """
-        #must be list and proper dict
-        msg = 'data_cols must be a list of data columns'
-        assert len(data_cols)>0 and isinstance(data_cols, list), msg
-        msg = f'data_mappers missing one or all of keys: {data_cols}'
+        # must be list and proper dict
+        msg = "data_cols must be a list of data columns"
+        assert len(data_cols) > 0 and isinstance(data_cols, list), msg
+        msg = f"data_mappers missing one or all of keys: {data_cols}"
         assert all([i in data_mappers.keys() for i in data_cols]), msg
-        #assert all mapper values are integer
-        msg = 'All mapper values must be integer codes'
+        # assert all mapper values are integer
+        msg = "All mapper values must be integer codes"
         for m in data_mappers.values():
             assert all([isinstance(v, int) for v in m.values()]), msg
-        #check fill value
-        assert isinstance(fill, int), 'fill value must be integer'
-        #set out path
+        # check fill value
+        assert isinstance(fill, int), "fill value must be integer"
+        # set out path
         out_path = self._set_out_path(out_path)
-        #get the files to process
-        pkl_groups = list(zip(*self._get_files_tracks_to_process(agents, tracks)))
-        #map agent data in parallel
-        utils.pool_caller(maps.map_agent_data_to_codes,
-                          (data_cols, data_mappers, out_path, drop, fill),
-                          pkl_groups,
-                          desc,
-                          ncores)
-        #update meta
+        # get the files to process
+        pkl_groups = list(
+            zip(*self._get_files_tracks_to_process(agents, tracks))
+        )
+        # map agent data in parallel
+        utils.pool_caller(
+            maps.map_agent_data_to_codes,
+            (data_cols, data_mappers, out_path, drop, fill),
+            pkl_groups,
+            desc,
+            ncores,
+        )
+        # update meta
         self = self._update_meta(out_path, self.meta)
         return self
 
     ############################################################################
-    #FETCHERS
+    # FETCHERS
     ############################################################################
 
-    #make deepcopy
+    # make deepcopy
     def copy(self):
         """
         Creates a deepcopy of the input Dataset.
@@ -1298,8 +1373,8 @@ class Dataset:
             Dataset: Deepcopy of the input Dataset.
         """
         return deepcopy(self)
-    
-    #get one agent
+
+    # get one agent
     def get_agent(self, agent):
         """
         Reads and returns one single agent file, specified by Agent ID.
@@ -1310,9 +1385,9 @@ class Dataset:
         Returns:
             Dataset: The requested agent.
         """
-        return utils.collect_agent_pkls(self._file_mapper['Agents'][agent])
-    
-    #get specific agents
+        return utils.collect_agent_pkls(self._file_mapper["Agents"][agent])
+
+    # get specific agents
     def get_agents(self, agents, ncores=1):
         """
         Reads and returns a list of agent files, specified by Agent IDs.
@@ -1323,17 +1398,22 @@ class Dataset:
         Returns:
             list: List of the requested agents.
         """
-        agent_files = self._file_mapper['Agents']
+        agent_files = self._file_mapper["Agents"]
         files = [agent_files[a] for a in agents]
-        #process in parallel
+        # process in parallel
         with mp.Pool(ncores) as pool:
-            out = pool.map(utils.collect_agent_pkls, tqdm(files, 
-                                                          desc=GREEN+'Getting agents'+ENDC,
-                                                          total=len(files),
-                                                          colour='GREEN'))
+            out = pool.map(
+                utils.collect_agent_pkls,
+                tqdm(
+                    files,
+                    desc=GREEN + "Getting agents" + ENDC,
+                    total=len(files),
+                    colour="GREEN",
+                ),
+            )
         return out
-    
-    #get one track
+
+    # get one track
     def get_track(self, track):
         """
         Reads and returns one single track, specified by Track ID.
@@ -1344,12 +1424,12 @@ class Dataset:
         Returns:
             Dataset: The requested track.
         """
-        aid, tid = track.rsplit('_',1)
-        file = self._file_mapper['Tracks'][aid]
+        aid, tid = track.rsplit("_", 1)
+        file = self._file_mapper["Tracks"][aid]
         a = utils.read_pkl(file)
         return a.tracks[tid]
-            
-    #get specific tracks
+
+    # get specific tracks
     def get_tracks(self, tracks, ncores=1):
         """
         Reads and returns a list of tracks, specified by Track IDs.
@@ -1360,15 +1440,20 @@ class Dataset:
         Returns:
             list: List of the requested tracks.
         """
-        aids = list(map(lambda x: x.rsplit('_', 1)[0], tracks))
-        files = [self._file_mapper['Tracks'][a] for a in aids]
-        #process in parallel
+        aids = list(map(lambda x: x.rsplit("_", 1)[0], tracks))
+        files = [self._file_mapper["Tracks"][a] for a in aids]
+        # process in parallel
         with mp.Pool(ncores) as pool:
-            out = pool.map(utils.read_pkl, tqdm(files, 
-                                                desc=GREEN+'Getting tracks'+ENDC,
-                                                total=len(files), 
-                                                colour='GREEN'))
-        #collect tracks
+            out = pool.map(
+                utils.read_pkl,
+                tqdm(
+                    files,
+                    desc=GREEN + "Getting tracks" + ENDC,
+                    total=len(files),
+                    colour="GREEN",
+                ),
+            )
+        # collect tracks
         out_tracks = []
         for ves in out:
             for tid in ves.tracks.keys():
@@ -1376,16 +1461,18 @@ class Dataset:
                     out_tracks.append(ves.tracks[tid])
         return out_tracks
 
-    def to_gdf(self, 
-               agents=None,
-               tracks=None,
-               code=None,
-               ncores=1,
-               segments=False,
-               method='middle',
-               desc='Converting tracks to GeoDataFrame'):
+    def to_gdf(
+        self,
+        agents=None,
+        tracks=None,
+        code=None,
+        ncores=1,
+        segments=False,
+        method="middle",
+        desc="Converting tracks to GeoDataFrame",
+    ):
         """
-        Converts requested agents/tracks into a GeoDataFrame (gdf). 
+        Converts requested agents/tracks into a GeoDataFrame (gdf).
 
         By default, one LineString is created for each track. You can pass segments=True to "explode"
         these LineStrings and create N number of LineString segments for each track that has N+1 points.
@@ -1419,43 +1506,45 @@ class Dataset:
         Returns:
             GeoDataFrame: A GeoPandas GeoDataFrame containing the converted track data.
         """
-        #change desc
+        # change desc
         if segments:
-            desc = 'Converting track segments to GeoDataFrame'
-        #assert method is valid
+            desc = "Converting track segments to GeoDataFrame"
+        # assert method is valid
         if segments:
-            msg = 'method must be backward, middle, or forward'
-            assert method in ['backward','middle','forward'], msg
-        #get the files to process
-        pkl_groups = list(zip(*self._get_files_tracks_to_process(agents, tracks)))  
-        #process to gdf in parallel
-        rows = utils.pool_caller(io.to_gdf,
-                                 (code, segments, method),
-                                 pkl_groups,
-                                 desc,
-                                 ncores)
-        #flatten and convert to gdf
+            msg = "method must be backward, middle, or forward"
+            assert method in ["backward", "middle", "forward"], msg
+        # get the files to process
+        pkl_groups = list(
+            zip(*self._get_files_tracks_to_process(agents, tracks))
+        )
+        # process to gdf in parallel
+        rows = utils.pool_caller(
+            io.to_gdf, (code, segments, method), pkl_groups, desc, ncores
+        )
+        # flatten and convert to gdf
         rows = utils.flatten(rows)
-        #if empty
+        # if empty
         if len(rows) == 0:
             gdf = gp.GeoDataFrame()
         else:
-            gdf = gp.GeoDataFrame(rows, 
-                                  crs=self.meta['CRS'], 
-                                  geometry='geometry')
-            #make index column
+            gdf = gp.GeoDataFrame(
+                rows, crs=self.meta["CRS"], geometry="geometry"
+            )
+            # make index column
             if segments:
-                gdf.index = gdf['Segment ID'].values
+                gdf.index = gdf["Segment ID"].values
             else:
-                gdf.index = gdf['Track ID'].values
+                gdf.index = gdf["Track ID"].values
         return gdf
-    
-    def to_df(self,
-              agents=None,
-              tracks=None,
-              code=None,
-              ncores=1,
-              desc='Converting tracks to DataFrame'):
+
+    def to_df(
+        self,
+        agents=None,
+        tracks=None,
+        code=None,
+        ncores=1,
+        desc="Converting tracks to DataFrame",
+    ):
         """
         Converts agent/track data into a pandas DataFrame. This method allows for simple integration
         of pandas into data processing workflows, and leveraging the pandas framework and built-in tools.
@@ -1483,20 +1572,17 @@ class Dataset:
         Returns:
             DataFrame: A pandas DataFrame containing the converted data.
         """
-        #get the files to process
-        pkl_groups = list(zip(*self._get_files_tracks_to_process(agents, tracks)))  
-        #process to gdf in parallel
-        dfs = utils.pool_caller(io.to_df,
-                                (code,),
-                                pkl_groups,
-                                desc,
-                                ncores)
-        #flatten and convert to df
+        # get the files to process
+        pkl_groups = list(
+            zip(*self._get_files_tracks_to_process(agents, tracks))
+        )
+        # process to gdf in parallel
+        dfs = utils.pool_caller(io.to_df, (code,), pkl_groups, desc, ncores)
+        # flatten and convert to df
         dfs = utils.flatten(dfs)
         return pd.concat(dfs)
-    
-    def to_dask_bag(self, 
-                    agents=None):
+
+    def to_dask_bag(self, agents=None):
         """
         Converts the dataset for specified agents into a Dask Bag, enabling parallel processing and analysis
         of large datasets that do not fit into memory. Dask Bags are well-suited for working with unstructured
@@ -1515,31 +1601,33 @@ class Dataset:
         Returns:
             dask.bag.Bag: A Dask Bag object where each element in the bag is a trackio.Agent.
         """
-        #get the files to process
+        # get the files to process
         pkl_files, _ = self._get_files_tracks_to_process(agents, None)
         pkl_files = utils.flatten(pkl_files)
-        #create bag
+        # create bag
         bag = db.from_sequence(pkl_files)
         return bag.map(utils.read_pkl)
 
     ############################################################################
-    #GEOMETRIC
+    # GEOMETRIC
     ############################################################################
-    
-    def reproject_crs(self, 
-                      crs,
-                      agents=None,
-                      tracks=None, 
-                      ncores=1, 
-                      out_path=None,
-                      desc='Reprojecting CRS'):
+
+    def reproject_crs(
+        self,
+        crs,
+        agents=None,
+        tracks=None,
+        ncores=1,
+        out_path=None,
+        desc="Reprojecting CRS",
+    ):
         """
         Reprojects the coordinate reference system (CRS) of the dataset's geographic data to a new CRS.
 
         The target CRS can be a EPSG code, WKT string, pyproj.CRS object, etc.
 
         If you pass a directory for the out_path kwarg, the *.tracks files will be saved to this directory,
-        and self.data_path will be changed as well. If you pass None, it simply saves the *.tracks files 
+        and self.data_path will be changed as well. If you pass None, it simply saves the *.tracks files
         in the original self.data_path location.
 
         Args:
@@ -1558,42 +1646,48 @@ class Dataset:
         Returns:
             self: The Dataset instance.
         """
-        #set out path
+        # set out path
         out_path = self._set_out_path(out_path)
-        #get the files to process
-        pkl_groups = list(zip(*self._get_files_tracks_to_process(agents, tracks)))
-        #get crs
-        crs1 = CRS(self.meta['CRS'])
+        # get the files to process
+        pkl_groups = list(
+            zip(*self._get_files_tracks_to_process(agents, tracks))
+        )
+        # get crs
+        crs1 = CRS(self.meta["CRS"])
         crs2 = CRS(crs)
-        #if already same crs
+        # if already same crs
         if crs1.equals(crs2):
             pass
-        #if different crs
+        # if different crs
         else:
-            #make transformer once
+            # make transformer once
             transformer = Transformer.from_crs(crs1, crs2, always_xy=True)
-            #reproject in parallel
-            utils.pool_caller(geometry.reproject_crs,
-                                (transformer, out_path),
-                                pkl_groups,
-                                desc, 
-                                ncores)
-            #reset/write the meta
+            # reproject in parallel
+            utils.pool_caller(
+                geometry.reproject_crs,
+                (transformer, out_path),
+                pkl_groups,
+                desc,
+                ncores,
+            )
+            # reset/write the meta
             meta = self.meta.copy()
-            meta['CRS'] = crs2
-            meta['X'] = crs2.axis_info[0].unit_name
-            meta['Y'] = crs2.axis_info[1].unit_name
-            #update meta
+            meta["CRS"] = crs2
+            meta["X"] = crs2.axis_info[0].unit_name
+            meta["Y"] = crs2.axis_info[1].unit_name
+            # update meta
             self = self._update_meta(out_path, meta)
         return self
-         
-    def resample_spacing(self, 
-                         spacing, 
-                         agents=None,
-                         tracks=None, 
-                         ncores=1, 
-                         out_path=None,
-                         desc='Resampling track spacing'):
+
+    def resample_spacing(
+        self,
+        spacing,
+        agents=None,
+        tracks=None,
+        ncores=1,
+        out_path=None,
+        desc="Resampling track spacing",
+    ):
         """
         Resamples the points of tracks to a specified spacing. This is useful for standardizing
         the distance between consecutive points in track data, facilitating analyses that require uniform
@@ -1601,7 +1695,7 @@ class Dataset:
         desired spacing.
 
         If you pass a directory for the out_path kwarg, the *.tracks files will be saved to this directory,
-        and self.data_path will be changed as well. If you pass None, it simply saves the *.tracks files 
+        and self.data_path will be changed as well. If you pass None, it simply saves the *.tracks files
         in the original self.data_path location.
 
 
@@ -1623,27 +1717,33 @@ class Dataset:
         Returns:
             self: The Dataset instance.
         """
-        #set out path
+        # set out path
         out_path = self._set_out_path(out_path)
-        #get the files to process
-        pkl_groups = list(zip(*self._get_files_tracks_to_process(agents, tracks)))
-        #resample in parallel
-        utils.pool_caller(geometry.resample_spacing,
-                          (spacing, out_path),
-                          pkl_groups,
-                          desc,
-                          ncores)
-        #update meta
+        # get the files to process
+        pkl_groups = list(
+            zip(*self._get_files_tracks_to_process(agents, tracks))
+        )
+        # resample in parallel
+        utils.pool_caller(
+            geometry.resample_spacing,
+            (spacing, out_path),
+            pkl_groups,
+            desc,
+            ncores,
+        )
+        # update meta
         self = self._update_meta(out_path, self.meta)
         return self
-        
-    def resample_time(self, 
-                      seconds, 
-                      agents=None,
-                      tracks=None, 
-                      ncores=1, 
-                      out_path=None,
-                      desc='Resampling track timing'):
+
+    def resample_time(
+        self,
+        seconds,
+        agents=None,
+        tracks=None,
+        ncores=1,
+        out_path=None,
+        desc="Resampling track timing",
+    ):
         """
         Resamples the points of tracks to a specified temporal spacing. This is useful for standardizing
         the timing between consecutive points in track data, facilitating analyses that require uniform
@@ -1651,7 +1751,7 @@ class Dataset:
         desired temporal spacing.
 
         If you pass a directory for the out_path kwarg, the *.tracks files will be saved to this directory,
-        and self.data_path will be changed as well. If you pass None, it simply saves the *.tracks files 
+        and self.data_path will be changed as well. If you pass None, it simply saves the *.tracks files
         in the original self.data_path location.
 
         Args:
@@ -1670,27 +1770,33 @@ class Dataset:
         Returns:
             self: The Dataset instance.
         """
-        #set out path
+        # set out path
         out_path = self._set_out_path(out_path)
-        #get the files to process
-        pkl_groups = list(zip(*self._get_files_tracks_to_process(agents, tracks)))
-        #resample in parallel
-        utils.pool_caller(geometry.resample_time,
-                          (seconds, out_path),
-                          pkl_groups,
-                          desc,
-                          ncores)
-        #update meta
+        # get the files to process
+        pkl_groups = list(
+            zip(*self._get_files_tracks_to_process(agents, tracks))
+        )
+        # resample in parallel
+        utils.pool_caller(
+            geometry.resample_time,
+            (seconds, out_path),
+            pkl_groups,
+            desc,
+            ncores,
+        )
+        # update meta
         self = self._update_meta(out_path, self.meta)
         return self
-    
-    def resample_time_global(self, 
-                             time, 
-                             agents=None,
-                             tracks=None, 
-                             ncores=1, 
-                             out_path=None,
-                             desc='Resampling tracks to global time axis'):
+
+    def resample_time_global(
+        self,
+        time,
+        agents=None,
+        tracks=None,
+        ncores=1,
+        out_path=None,
+        desc="Resampling tracks to global time axis",
+    ):
         """
         Resamples the points of tracks to a global time axis.
 
@@ -1701,7 +1807,7 @@ class Dataset:
         This may also be useful for standardizing data for ML approaches.
 
         If you pass a directory for the out_path kwarg, the *.tracks files will be saved to this directory,
-        and self.data_path will be changed as well. If you pass None, it simply saves the *.tracks files 
+        and self.data_path will be changed as well. If you pass None, it simply saves the *.tracks files
         in the original self.data_path location.
 
         Args:
@@ -1721,43 +1827,49 @@ class Dataset:
         Returns:
             self: The Dataset instance.
         """
-        #convert incase
+        # convert incase
         time = pd.to_datetime(time)
-        #assert entire dataset is spanned
+        # assert entire dataset is spanned
         adb = self.agents
-        start = adb['Start Time'].min()
-        end = adb['End Time'].max()
-        msg = f'Global time must span entire dataset from {start} to {end} inclusive'
+        start = adb["Start Time"].min()
+        end = adb["End Time"].max()
+        msg = f"Global time must span entire dataset from {start} to {end} inclusive"
         assert start >= time[0] and end <= time[-1], msg
-        #convert times to seconds
-        _time = time.astype(np.int64)/1e9 #seconds
-        #set out path
+        # convert times to seconds
+        _time = time.astype(np.int64) / 1e9  # seconds
+        # set out path
         out_path = self._set_out_path(out_path)
-        #get the files to process
-        pkl_groups = list(zip(*self._get_files_tracks_to_process(agents, tracks)))
-        #resample in parallel
-        utils.pool_caller(geometry.resample_time_global,
-                          (_time, out_path),
-                          pkl_groups,
-                          desc,
-                          ncores)
-        #update meta
+        # get the files to process
+        pkl_groups = list(
+            zip(*self._get_files_tracks_to_process(agents, tracks))
+        )
+        # resample in parallel
+        utils.pool_caller(
+            geometry.resample_time_global,
+            (_time, out_path),
+            pkl_groups,
+            desc,
+            ncores,
+        )
+        # update meta
         self = self._update_meta(out_path, self.meta)
-        return self    
+        return self
 
-    def compute_coursing(self, 
-                         agents=None,
-                         tracks=None, 
-                         ncores=1, 
-                         out_path=None,
-                         method='middle',
-                         desc='Computing coursing'):
+    def compute_coursing(
+        self,
+        agents=None,
+        tracks=None,
+        ncores=1,
+        out_path=None,
+        method="middle",
+        desc="Computing coursing",
+    ):
         """
         Computes the coursing of tracks based on the direction travelled between points. This gets added
         as a "Coursing" column in the track data.
 
         The method kwarg must be one of ['forward', 'middle', 'backward'] and corresponds to which pairs of
-        points to use for determining coursing values, and how to fill the remaining point. 
+        points to use for determining coursing values, and how to fill the remaining point.
 
         If 'forward', the coursing at each point is calculated by the direction from the current
         point to the next point. The first point on the track then gets filled with the coursing of the second point.
@@ -1768,9 +1880,9 @@ class Dataset:
         If 'middle', it uses an average of both and no filling is required.
 
         If you pass a directory for the out_path kwarg, the *.tracks files will be saved to this directory,
-        and self.data_path will be changed as well. If you pass None, it simply saves the *.tracks files 
+        and self.data_path will be changed as well. If you pass None, it simply saves the *.tracks files
         in the original self.data_path location.
-        
+
         Args:
             agents (list, optional): A list of agent IDs for which coursing will be computed. If None, coursing
                                     will be computed for all agents available in the dataset.
@@ -1787,32 +1899,38 @@ class Dataset:
         Returns:
             self: The Dataset instance.
         """
-        #assert method
-        msg = 'method must be backward, middle, or forward'
-        assert method in ['backward','middle','forward'], msg
-        #set out path
+        # assert method
+        msg = "method must be backward, middle, or forward"
+        assert method in ["backward", "middle", "forward"], msg
+        # set out path
         out_path = self._set_out_path(out_path)
-        #get the files to process
-        pkl_groups = list(zip(*self._get_files_tracks_to_process(agents, tracks)))
-        #recompute in parallel
-        utils.pool_caller(geometry.compute_coursing,
-                          (method, self.meta['CRS'], out_path),
-                          pkl_groups,
-                          desc,
-                          ncores)       
-        #update meta
+        # get the files to process
+        pkl_groups = list(
+            zip(*self._get_files_tracks_to_process(agents, tracks))
+        )
+        # recompute in parallel
+        utils.pool_caller(
+            geometry.compute_coursing,
+            (method, self.meta["CRS"], out_path),
+            pkl_groups,
+            desc,
+            ncores,
+        )
+        # update meta
         meta = self.meta.copy()
-        meta['Coursing'] = 'degrees'
+        meta["Coursing"] = "degrees"
         self = self._update_meta(out_path, meta)
         return self
-    
-    def compute_turning_rate(self, 
-                             agents=None,
-                             tracks=None, 
-                             ncores=1, 
-                             out_path=None,
-                             method='middle',
-                             desc='Computing turning rate'):
+
+    def compute_turning_rate(
+        self,
+        agents=None,
+        tracks=None,
+        ncores=1,
+        out_path=None,
+        method="middle",
+        desc="Computing turning rate",
+    ):
         """
         Computes the turning rate of tracks based on the change in coursing between points. This gets added
         as a "Turning Rate" column in the track data.
@@ -1821,7 +1939,7 @@ class Dataset:
         not the case, you should run the Dataset.compute_coursing function first.
 
         The method kwarg must be one of ['forward', 'middle', 'backward'] and corresponds to which pairs of
-        points to use for determining turning rate values, and how to fill the remaining point. 
+        points to use for determining turning rate values, and how to fill the remaining point.
 
         If 'forward', the turning rate at each point is calculated by the change in coursing from the current
         point to the next point. The first point on the track then gets filled with the value of the second point.
@@ -1830,9 +1948,9 @@ class Dataset:
         the value of the second last point.
 
         If 'middle', it uses an average of both and no filling is required.
-        
+
         If you pass a directory for the out_path kwarg, the *.tracks files will be saved to this directory,
-        and self.data_path will be changed as well. If you pass None, it simply saves the *.tracks files 
+        and self.data_path will be changed as well. If you pass None, it simply saves the *.tracks files
         in the original self.data_path location.
 
         Args:
@@ -1851,38 +1969,44 @@ class Dataset:
         Returns:
             self: The Dataset instance.
         """
-        #assert method
-        msg = 'method must be backward, middle, or forward'
-        assert method in ['backward','middle','forward'], msg
-        #set out path
+        # assert method
+        msg = "method must be backward, middle, or forward"
+        assert method in ["backward", "middle", "forward"], msg
+        # set out path
         out_path = self._set_out_path(out_path)
-        #get the files to process
-        pkl_groups = list(zip(*self._get_files_tracks_to_process(agents, tracks)))
-        #recompute in parallel
-        utils.pool_caller(geometry.compute_turning_rate,
-                          (method, out_path),
-                          pkl_groups,
-                          desc,
-                          ncores)       
-        #update meta
+        # get the files to process
+        pkl_groups = list(
+            zip(*self._get_files_tracks_to_process(agents, tracks))
+        )
+        # recompute in parallel
+        utils.pool_caller(
+            geometry.compute_turning_rate,
+            (method, out_path),
+            pkl_groups,
+            desc,
+            ncores,
+        )
+        # update meta
         meta = self.meta.copy()
-        meta['Turning Rate'] = 'degrees/sec'
+        meta["Turning Rate"] = "degrees/sec"
         self = self._update_meta(out_path, meta)
         return self
 
-    def compute_speed(self, 
-                      agents=None,
-                      tracks=None, 
-                      ncores=1, 
-                      out_path=None,
-                      method='middle',
-                      desc='Computing speed'):
+    def compute_speed(
+        self,
+        agents=None,
+        tracks=None,
+        ncores=1,
+        out_path=None,
+        method="middle",
+        desc="Computing speed",
+    ):
         """
         Computes the speed of tracks based on the distance/time between points. This gets added
         as a "Speed" column in the track data.
 
         The method kwarg must be one of ['forward', 'middle', 'backward'] and corresponds to which pairs of
-        points to use for determining speed values, and how to fill the remaining point. 
+        points to use for determining speed values, and how to fill the remaining point.
 
         If 'forward', the speed at each point is calculated by the change in distance/time from the current
         point to the next point. The first point on the track then gets filled with the value of the second point.
@@ -1891,9 +2015,9 @@ class Dataset:
         the value of the second last point.
 
         If 'middle', it uses an average of both and no filling is required.
-        
+
         If you pass a directory for the out_path kwarg, the *.tracks files will be saved to this directory,
-        and self.data_path will be changed as well. If you pass None, it simply saves the *.tracks files 
+        and self.data_path will be changed as well. If you pass None, it simply saves the *.tracks files
         in the original self.data_path location.
 
         Args:
@@ -1912,32 +2036,38 @@ class Dataset:
         Returns:
             self: The Dataset instance.
         """
-        #assert method
-        msg = 'method must be backward, middle, or forward'
-        assert method in ['backward','middle','forward'], msg
-        #set out path
+        # assert method
+        msg = "method must be backward, middle, or forward"
+        assert method in ["backward", "middle", "forward"], msg
+        # set out path
         out_path = self._set_out_path(out_path)
-        #get the files to process
-        pkl_groups = list(zip(*self._get_files_tracks_to_process(agents, tracks)))
-        #recompute in parallel
-        utils.pool_caller(geometry.compute_speed,
-                          (method, out_path),
-                          pkl_groups,
-                          desc,
-                          ncores)  
-        #update meta
+        # get the files to process
+        pkl_groups = list(
+            zip(*self._get_files_tracks_to_process(agents, tracks))
+        )
+        # recompute in parallel
+        utils.pool_caller(
+            geometry.compute_speed,
+            (method, out_path),
+            pkl_groups,
+            desc,
+            ncores,
+        )
+        # update meta
         meta = self.meta.copy()
-        meta['Speed'] = f"{meta['X']}/second"
+        meta["Speed"] = f"{meta['X']}/second"
         self = self._update_meta(out_path, meta)
         return self
 
-    def compute_acceleration(self, 
-                             agents=None,
-                             tracks=None, 
-                             ncores=1, 
-                             out_path=None,
-                             method='middle',
-                             desc='Computing acceleration'):
+    def compute_acceleration(
+        self,
+        agents=None,
+        tracks=None,
+        ncores=1,
+        out_path=None,
+        method="middle",
+        desc="Computing acceleration",
+    ):
         """
         Computes the acceleration of tracks based on the distance/time between points. This gets added
         as an "Acceleration" column in the track data.
@@ -1946,7 +2076,7 @@ class Dataset:
         not the case, you should run the Dataset.compute_speed method first.
 
         The method kwarg must be one of ['forward', 'middle', 'backward'] and corresponds to which pairs of
-        points to use for determining acceleration values, and how to fill the remaining point. 
+        points to use for determining acceleration values, and how to fill the remaining point.
 
         If 'forward', the acceleration at each point is calculated by the change in speed from the current
         point to the next point. The first point on the track then gets filled with the value of the second point.
@@ -1955,9 +2085,9 @@ class Dataset:
         the value of the second last point.
 
         If 'middle', it uses an average of both and no filling is required.
-        
+
         If you pass a directory for the out_path kwarg, the *.tracks files will be saved to this directory,
-        and self.data_path will be changed as well. If you pass None, it simply saves the *.tracks files 
+        and self.data_path will be changed as well. If you pass None, it simply saves the *.tracks files
         in the original self.data_path location.
 
         Args:
@@ -1976,36 +2106,42 @@ class Dataset:
         Returns:
             self: The Dataset instance.
         """
-        #assert method
-        msg = 'method must be backward, middle, or forward'
-        assert method in ['backward','middle','forward'], msg
-        #set out path
+        # assert method
+        msg = "method must be backward, middle, or forward"
+        assert method in ["backward", "middle", "forward"], msg
+        # set out path
         out_path = self._set_out_path(out_path)
-        #get the files to process
-        pkl_groups = list(zip(*self._get_files_tracks_to_process(agents, tracks)))
-        #recompute in parallel
-        utils.pool_caller(geometry.compute_acceleration,
-                          (out_path, method),
-                          pkl_groups,
-                          desc,
-                          ncores)  
-        #update meta
+        # get the files to process
+        pkl_groups = list(
+            zip(*self._get_files_tracks_to_process(agents, tracks))
+        )
+        # recompute in parallel
+        utils.pool_caller(
+            geometry.compute_acceleration,
+            (out_path, method),
+            pkl_groups,
+            desc,
+            ncores,
+        )
+        # update meta
         meta = self.meta.copy()
-        meta['Acceleration'] = f"{meta['Speed']}/second"
+        meta["Acceleration"] = f"{meta['Speed']}/second"
         self = self._update_meta(out_path, meta)
         return self
 
-    def compute_distance_travelled(self, 
-                                   relative=False,
-                                   agents=None,
-                                   tracks=None, 
-                                   ncores=1, 
-                                   out_path=None,
-                                   desc='Computing distance travelled along tracks'):
+    def compute_distance_travelled(
+        self,
+        relative=False,
+        agents=None,
+        tracks=None,
+        ncores=1,
+        out_path=None,
+        desc="Computing distance travelled along tracks",
+    ):
         """
         Computes the total distance travelled along each track. This gets added
         as a "Distance Travelled" column in the track data.
-        
+
         The computation can be done in an absolute sense which captures the true distance travelled
         along the track. Or, it can be done relatively where every track is normalized to travel from 0-1.
 
@@ -2023,47 +2159,53 @@ class Dataset:
                                 along tracks'.
 
         If you pass a directory for the out_path kwarg, the *.tracks files will be saved to this directory,
-        and self.data_path will be changed as well. If you pass None, it simply saves the *.tracks files 
+        and self.data_path will be changed as well. If you pass None, it simply saves the *.tracks files
         in the original self.data_path location.
 
         Returns:
             self: The Dataset instance.
         """
-        #set out path
+        # set out path
         out_path = self._set_out_path(out_path)
-        #get the files to process
-        pkl_groups = list(zip(*self._get_files_tracks_to_process(agents, tracks)))
-        #recompute in parallel
-        utils.pool_caller(geometry.compute_distance_travelled,
-                          (out_path, relative),
-                          pkl_groups,
-                          desc,
-                          ncores)  
-        #update meta
+        # get the files to process
+        pkl_groups = list(
+            zip(*self._get_files_tracks_to_process(agents, tracks))
+        )
+        # recompute in parallel
+        utils.pool_caller(
+            geometry.compute_distance_travelled,
+            (out_path, relative),
+            pkl_groups,
+            desc,
+            ncores,
+        )
+        # update meta
         meta = self.meta.copy()
-        meta['Distance Travelled'] = meta['X']
+        meta["Distance Travelled"] = meta["X"]
         self = self._update_meta(out_path, meta)
         return self
 
-    def compute_radius_of_curvature(self, 
-                                   agents=None,
-                                   tracks=None, 
-                                   ncores=1, 
-                                   out_path=None,
-                                   desc='Computing radius of curvature'):
+    def compute_radius_of_curvature(
+        self,
+        agents=None,
+        tracks=None,
+        ncores=1,
+        out_path=None,
+        desc="Computing radius of curvature",
+    ):
         """
         Computes the radius of curvature for each point along tracks. This gets added
         as a "Radius of Curvature" column in the track data.
 
         This is very useful for isolating parts of tracks where agents are turning.
-        
-        This algorithm works by looking at points along each track, along with the 2 neighbouring points. 
+
+        This algorithm works by looking at points along each track, along with the 2 neighbouring points.
         These 3 points are then used to construct a circle, and the radius of this circle is the Radius of Curvature
-        at the middle point. Naturally, this results in a nan value for the first and last points of the tracks, 
+        at the middle point. Naturally, this results in a nan value for the first and last points of the tracks,
         since they only have 1 neighbour.
 
         If you pass a directory for the out_path kwarg, the *.tracks files will be saved to this directory,
-        and self.data_path will be changed as well. If you pass None, it simply saves the *.tracks files 
+        and self.data_path will be changed as well. If you pass None, it simply saves the *.tracks files
         in the original self.data_path location.
 
         Args:
@@ -2080,39 +2222,45 @@ class Dataset:
         Returns:
             self: The Dataset instance.
         """
-        #set out path
+        # set out path
         out_path = self._set_out_path(out_path)
-        #get the files to process
-        pkl_groups = list(zip(*self._get_files_tracks_to_process(agents, tracks)))
-        #recompute in parallel
-        utils.pool_caller(geometry.compute_radius_of_curvature,
-                          (out_path,),
-                          pkl_groups,
-                          desc,
-                          ncores)  
-        #update meta
+        # get the files to process
+        pkl_groups = list(
+            zip(*self._get_files_tracks_to_process(agents, tracks))
+        )
+        # recompute in parallel
+        utils.pool_caller(
+            geometry.compute_radius_of_curvature,
+            (out_path,),
+            pkl_groups,
+            desc,
+            ncores,
+        )
+        # update meta
         meta = self.meta.copy()
-        meta['Radius of Curvature'] = meta['X']
+        meta["Radius of Curvature"] = meta["X"]
         self = self._update_meta(out_path, meta)
         return self
 
-    def compute_sinuosity(self, 
-                          agents=None,
-                          tracks=None, 
-                          ncores=1, 
-                          out_path=None,
-                          window=3,
-                          desc='Computing sinuosity'):
+    def compute_sinuosity(
+        self,
+        agents=None,
+        tracks=None,
+        ncores=1,
+        out_path=None,
+        window=3,
+        desc="Computing sinuosity",
+    ):
         """
         Computes the sinuosity for each point along tracks. This gets added as a "Sinuosity" column in the track data.
-        
+
         This algorithm works by looking at a central middle point, as well as a user-defined window of points centered
         at this point. The sinuosity is then calculated as the ratio between total length and effective length
         (distance between start and end points) for the window of points. Naturally, this will result in nan values
         at the beginning and end of the track depending on how large the window is.
 
         If you pass a directory for the out_path kwarg, the *.tracks files will be saved to this directory,
-        and self.data_path will be changed as well. If you pass None, it simply saves the *.tracks files 
+        and self.data_path will be changed as well. If you pass None, it simply saves the *.tracks files
         in the original self.data_path location.
 
         Args:
@@ -2131,31 +2279,37 @@ class Dataset:
         Returns:
             self: The Dataset instance.
         """
-        #assert odd window number to be centered on each point
-        assert window%2 > 0, 'window must be an odd number'
-        #set out path
+        # assert odd window number to be centered on each point
+        assert window % 2 > 0, "window must be an odd number"
+        # set out path
         out_path = self._set_out_path(out_path)
-        #get the files to process
-        pkl_groups = list(zip(*self._get_files_tracks_to_process(agents, tracks)))
-        #recompute in parallel
-        utils.pool_caller(geometry.compute_sinuosity,
-                          (out_path, window),
-                          pkl_groups,
-                          desc,
-                          ncores)  
-        #update meta
+        # get the files to process
+        pkl_groups = list(
+            zip(*self._get_files_tracks_to_process(agents, tracks))
+        )
+        # recompute in parallel
+        utils.pool_caller(
+            geometry.compute_sinuosity,
+            (out_path, window),
+            pkl_groups,
+            desc,
+            ncores,
+        )
+        # update meta
         meta = self.meta.copy()
-        meta['Sinuosity'] = 'non-dimensional'
+        meta["Sinuosity"] = "non-dimensional"
         self = self._update_meta(out_path, meta)
         return self
 
-    def smooth_corners(self, 
-                       refinements=2,
-                       agents=None,
-                       tracks=None, 
-                       ncores=1, 
-                       out_path=None,
-                       desc='Smoothing sharp corners'):
+    def smooth_corners(
+        self,
+        refinements=2,
+        agents=None,
+        tracks=None,
+        ncores=1,
+        out_path=None,
+        desc="Smoothing sharp corners",
+    ):
         """
         Smooths sharp corners/turns in tracks using a iterative weighted averaging technique.
 
@@ -2166,7 +2320,7 @@ class Dataset:
         Here, linear interpolation is used to fill any dynamic data at new points.
 
         If you pass a directory for the out_path kwarg, the *.tracks files will be saved to this directory,
-        and self.data_path will be changed as well. If you pass None, it simply saves the *.tracks files 
+        and self.data_path will be changed as well. If you pass None, it simply saves the *.tracks files
         in the original self.data_path location.
 
         Args:
@@ -2184,32 +2338,38 @@ class Dataset:
         Returns:
             self: The Dataset instance.
         """
-        #set out path
+        # set out path
         out_path = self._set_out_path(out_path)
-        #get the files to process
-        pkl_groups = list(zip(*self._get_files_tracks_to_process(agents, tracks)))
-        #resample in parallel
-        utils.pool_caller(geometry.smooth_corners,
-                          (refinements, out_path),
-                          pkl_groups,
-                          desc,
-                          ncores)
-        #update meta
+        # get the files to process
+        pkl_groups = list(
+            zip(*self._get_files_tracks_to_process(agents, tracks))
+        )
+        # resample in parallel
+        utils.pool_caller(
+            geometry.smooth_corners,
+            (refinements, out_path),
+            pkl_groups,
+            desc,
+            ncores,
+        )
+        # update meta
         self = self._update_meta(out_path, self.meta)
         return self
-            
-    def decimate_tracks(self, 
-                        epsilon=1,
-                        agents=None,
-                        tracks=None, 
-                        ncores=1, 
-                        out_path=None,
-                        desc='Decimating tracks'):
+
+    def decimate_tracks(
+        self,
+        epsilon=1,
+        agents=None,
+        tracks=None,
+        ncores=1,
+        out_path=None,
+        desc="Decimating tracks",
+    ):
         """
-        Decimates track geometry using the Douglas-Peucker algorithm. 
+        Decimates track geometry using the Douglas-Peucker algorithm.
 
         https://en.wikipedia.org/wiki/Ramer%E2%80%93Douglas%E2%80%93Peucker_algorithm
-        
+
         Decimation is very useful for reducing the size of the dataset, while still
         maintaining an appropriate level of detail.
 
@@ -2217,56 +2377,62 @@ class Dataset:
         meters for UTM, etc.
 
         If you pass a directory for the out_path kwarg, the *.tracks files will be saved to this directory,
-        and self.data_path will be changed as well. If you pass None, it simply saves the *.tracks files 
+        and self.data_path will be changed as well. If you pass None, it simply saves the *.tracks files
         in the original self.data_path location.
 
         Args:
-            epsilon (float, optional): The tolerance for decimation, determining the minimum distance 
-                                    a point must have from a line segment connecting adjacent points 
-                                    to be retained. Defaults to 1, with units depending on the CRS 
+            epsilon (float, optional): The tolerance for decimation, determining the minimum distance
+                                    a point must have from a line segment connecting adjacent points
+                                    to be retained. Defaults to 1, with units depending on the CRS
                                     of the track data (e.g., meters or degrees).
-            agents (list, optional): A list of agent IDs for which tracks will be decimated. If None, 
-                                    the decimation process is applied to tracks associated with all 
+            agents (list, optional): A list of agent IDs for which tracks will be decimated. If None,
+                                    the decimation process is applied to tracks associated with all
                                     agents in the dataset.
-            tracks (list, optional): A list of specific track IDs to be decimated. This allows for 
-                                    selective decimation of tracks. If None, the operation applies 
-                                    to tracks related to the specified agents or all tracks if no 
+            tracks (list, optional): A list of specific track IDs to be decimated. This allows for
+                                    selective decimation of tracks. If None, the operation applies
+                                    to tracks related to the specified agents or all tracks if no
                                     agents are specified.
-            ncores (int, optional): The number of processing cores to use for the decimation operation. 
+            ncores (int, optional): The number of processing cores to use for the decimation operation.
                                     Defaults to 1.
-            out_path (str, optional): The file path where the dataset with decimated tracks should be saved. 
+            out_path (str, optional): The file path where the dataset with decimated tracks should be saved.
                                     If None, it assumes the current data_path.
             desc (str, optional): A brief description of the decimation operation. Defaults to 'Decimating tracks'.
 
         Returns:
             self: The Dataset instance.
         """
-        #set out path
+        # set out path
         out_path = self._set_out_path(out_path)
-        #get the files to process
-        pkl_groups = list(zip(*self._get_files_tracks_to_process(agents, tracks)))
-        #resample in parallel
-        utils.pool_caller(geometry.decimate_tracks,
-                          (epsilon, out_path),
-                          pkl_groups,
-                          desc,
-                          ncores)
-        #update meta
+        # get the files to process
+        pkl_groups = list(
+            zip(*self._get_files_tracks_to_process(agents, tracks))
+        )
+        # resample in parallel
+        utils.pool_caller(
+            geometry.decimate_tracks,
+            (epsilon, out_path),
+            pkl_groups,
+            desc,
+            ncores,
+        )
+        # update meta
         self = self._update_meta(out_path, self.meta)
         return self
-       
-    def characteristic_tracks(self,
-                              stop_threshold=0.15,
-                              turn_threshold=22.5,
-                              min_distance=500,
-                              max_distance=20000,
-                              min_stop_duration=1800,
-                              agents=None,
-                              tracks=None, 
-                              ncores=1, 
-                              out_path=None,
-                              inplace=False,
-                              desc='Extracting characteristic tracks'):
+
+    def characteristic_tracks(
+        self,
+        stop_threshold=0.15,
+        turn_threshold=22.5,
+        min_distance=500,
+        max_distance=20000,
+        min_stop_duration=1800,
+        agents=None,
+        tracks=None,
+        ncores=1,
+        out_path=None,
+        inplace=False,
+        desc="Extracting characteristic tracks",
+    ):
         """
         Based on "Spatial Generalization and Aggregation of Massive Movement Data", Adrienko & Adrienko (2010).
 
@@ -2275,8 +2441,8 @@ class Dataset:
 
         Identifies and extracts characteristic tracks from existing tracks.
 
-        This method is useful for analyzing macroscopic behavior or movement patterns within track data, allowing for the 
-        identification of significant activities or navigation patterns based on parameters like stop duration, 
+        This method is useful for analyzing macroscopic behavior or movement patterns within track data, allowing for the
+        identification of significant activities or navigation patterns based on parameters like stop duration,
         turn angles, and travel distances.
 
         This method is also very useful for simplifying tracks to reduce dataset size, while maintaining an
@@ -2287,26 +2453,26 @@ class Dataset:
         True at characteristic points.
 
         If you pass a directory for the out_path kwarg, the *.tracks files will be saved to this directory,
-        and self.data_path will be changed as well. If you pass None, it simply saves the *.tracks files 
+        and self.data_path will be changed as well. If you pass None, it simply saves the *.tracks files
         in the original self.data_path location.
 
         Here all spatial/speed kwargs are in the CRS units. I.e. degrees for geographic, meters for UTM, etc.
 
         Args:
             stop_threshold (float, optional): The speed threshold below which a movement is considered a stop. Defaults to 0.15.
-            turn_threshold (float, optional): The minimum change in direction (in degrees) considered a significant 
+            turn_threshold (float, optional): The minimum change in direction (in degrees) considered a significant
                                                 turn. Defaults to 22.5 degrees.
             min_distance (float, optional): The minimum allowable distance between characteristic points. Defaults to 500.
             max_distance (float, optional): The maximum allowable distance between characteristic points. Defaults to 20000.
-            min_stop_duration (int, optional): The minimum duration (in seconds) of a stop to be considered significant. 
+            min_stop_duration (int, optional): The minimum duration (in seconds) of a stop to be considered significant.
                                                 Defaults to 1800 seconds (30 minutes).
-            agents (list, optional): A list of agent IDs to be analyzed. If None, the analysis is applied across all 
+            agents (list, optional): A list of agent IDs to be analyzed. If None, the analysis is applied across all
                                         agents in the dataset.
-            tracks (list, optional): A list of specific track IDs to be analyzed. This allows for focusing on particular 
-                                        tracks of interest. If None, the operation applies to tracks related to the specified 
+            tracks (list, optional): A list of specific track IDs to be analyzed. This allows for focusing on particular
+                                        tracks of interest. If None, the operation applies to tracks related to the specified
                                         agents or all tracks if no agents are specified.
             ncores (int, optional): The number of processing cores to use for the analysis. Defaults to 1.
-            out_path (str, optional): The file path where the dataset with the extracted characteristic tracks should be saved. 
+            out_path (str, optional): The file path where the dataset with the extracted characteristic tracks should be saved.
                                         If None, it assumes the current data_path.
             inplace (bool, optional): Whether to modify the dataset in place, or add a Characteristic column.
                                       Defaults to False, indicating not modifying in place.
@@ -2315,63 +2481,71 @@ class Dataset:
         Returns:
             self: The Dataset instance.
         """
-        #set out path
+        # set out path
         out_path = self._set_out_path(out_path)
-        #get the files to process
-        pkl_groups = list(zip(*self._get_files_tracks_to_process(agents, tracks)))
-        #process in parallel
-        utils.pool_caller(geometry.characteristic_tracks,
-                          (stop_threshold,
-                           turn_threshold,
-                           min_distance,
-                           max_distance,
-                           min_stop_duration,
-                           out_path,
-                           inplace),
-                          pkl_groups,
-                          desc,
-                          ncores)
-        #update meta
+        # get the files to process
+        pkl_groups = list(
+            zip(*self._get_files_tracks_to_process(agents, tracks))
+        )
+        # process in parallel
+        utils.pool_caller(
+            geometry.characteristic_tracks,
+            (
+                stop_threshold,
+                turn_threshold,
+                min_distance,
+                max_distance,
+                min_stop_duration,
+                out_path,
+                inplace,
+            ),
+            pkl_groups,
+            desc,
+            ncores,
+        )
+        # update meta
         meta = self.meta.copy()
-        meta['Characteristic'] = 'Characteristic Points'
+        meta["Characteristic"] = "Characteristic Points"
         self = self._update_meta(out_path, meta)
         return self
-    
-    def simplify_stops(self, 
-                       stop_threshold=0.15, 
-                       min_stop_duration=1800,
-                       max_drift_distance=1000,
-                       agents=None,
-                       tracks=None, 
-                       ncores=1, 
-                       out_path=None,
-                       desc='Simplifying stops along tracks'):
+
+    def simplify_stops(
+        self,
+        stop_threshold=0.15,
+        min_stop_duration=1800,
+        max_drift_distance=1000,
+        agents=None,
+        tracks=None,
+        ncores=1,
+        out_path=None,
+        desc="Simplifying stops along tracks",
+    ):
         """
         Simplifies and reduces the number of points that define stop events along tracks.
 
         This can be useful for simplifying large amounts of unnecessary data into key
-        points such as start/end points, which maintain the critical information of the stop 
+        points such as start/end points, which maintain the critical information of the stop
         (e.g. duration). In particular, this has proved useful to simplify AIS vessel tracks
         where AIS transponders have been left on at a mooring location for an extended period of time.
 
         If you pass a directory for the out_path kwarg, the *.tracks files will be saved to this directory,
-        and self.data_path will be changed as well. If you pass None, it simply saves the *.tracks files 
+        and self.data_path will be changed as well. If you pass None, it simply saves the *.tracks files
         in the original self.data_path location.
-        
+
         Here all spatial/speed kwargs are in the CRS units. I.e. degrees for geographic, meters for UTM, etc.
-        
+
         Args:
             stop_threshold (float, optional): The speed threshold below which a movement is considered a stop. Defaults to 0.15.
-            min_stop_duration (int, optional): The minimum duration (in seconds) of a stop to be considered significant. 
+            min_stop_duration (int, optional): The minimum duration (in seconds) of a stop to be considered significant.
                                                             Defaults to 1800 seconds (30 minutes).
             max_drift_distance (int, optional): The maximum allowable distance between stop points before an intermediate point
                                                 is maintained. Defaults to 1000.
-            agents (list, optional): A list of agent IDs for which stops will be simplified. If None, the simplification process 
+            agents (list, optional): A list of agent IDs for which stops will be simplified. If None, the simplification process
                                     is applied to stops associated with all agents in the dataset.
-            tracks (list, optional): A list of specific track IDs for which stops will be simplified. This allows for selective 
-                                    simplification of stops within certain tracks. If None, the operation applies to tracks related 
+            tracks (list, optional): A list of specific track IDs for which stops will be simplified. This allows for selective
+                                    simplification of stops within certain tracks. If None, the operation applies to tracks related
                                     to the specified agents or all tracks if no agents are specified.
-            ncores (int, optional): The number of processing cores to use for the simplification operation. Defaults to 1, 
+            ncores (int, optional): The number of processing cores to use for the simplification operation. Defaults to 1,
                                     implying serial processing. Utilizing more cores can speed up the process for large datasets.
             out_path (str, optional): The file path where the dataset with simplified stops should be saved. If None, it assumes
                                     the current data_path.
@@ -2380,46 +2554,49 @@ class Dataset:
         Returns:
             self: The Dataset instance.
         """
-        #set out path
+        # set out path
         out_path = self._set_out_path(out_path)
-        #get the files to process
-        pkl_groups = list(zip(*self._get_files_tracks_to_process(agents, tracks)))
-        #resample in parallel
-        utils.pool_caller(geometry.simplify_stops,
-                          (stop_threshold,
-                           min_stop_duration,
-                           max_drift_distance,
-                           out_path),
-                          pkl_groups,
-                          desc,
-                          ncores)
-        #update meta
+        # get the files to process
+        pkl_groups = list(
+            zip(*self._get_files_tracks_to_process(agents, tracks))
+        )
+        # resample in parallel
+        utils.pool_caller(
+            geometry.simplify_stops,
+            (stop_threshold, min_stop_duration, max_drift_distance, out_path),
+            pkl_groups,
+            desc,
+            ncores,
+        )
+        # update meta
         self = self._update_meta(out_path, self.meta)
         return self
-    
-    def imprint_geometry(self, 
-                         shape,
-                         agents=None,
-                         tracks=None, 
-                         ncores=1, 
-                         out_path=None,
-                         desc='Imprinting geometry into tracks'):
+
+    def imprint_geometry(
+        self,
+        shape,
+        agents=None,
+        tracks=None,
+        ncores=1,
+        out_path=None,
+        desc="Imprinting geometry into tracks",
+    ):
         """
-        Imprints a specified geometric shape onto track data. Shape must be a shapely LineString, 
+        Imprints a specified geometric shape onto track data. Shape must be a shapely LineString,
         MultiLineString, Polygon, or MultiPolygon. The shape must be in the same CRS as the data.
 
-        This is very useful for things like clipping tracks, isolating parts of tracks inside of polygons, 
+        This is very useful for things like clipping tracks, isolating parts of tracks inside of polygons,
         or getting an accurate estimate of time spent inside a polygon. This may also be useful if you simply
         want to add data to tracks at a very specific location for later use.
 
         Here, linear interpolation is used to fill any dynamic data at new points.
 
         If you pass a directory for the out_path kwarg, the *.tracks files will be saved to this directory,
-        and self.data_path will be changed as well. If you pass None, it simply saves the *.tracks files 
+        and self.data_path will be changed as well. If you pass None, it simply saves the *.tracks files
         in the original self.data_path location.
 
         Args:
-            shape: The geometric shape to be imprinted onto the tracks. Shape must be a shapely LineString, 
+            shape: The geometric shape to be imprinted onto the tracks. Shape must be a shapely LineString,
                   MultiLineString, Polygon, or MultiPolygon.
             agents (list, optional): A list of agent IDs whose tracks will be modified by the geometric shape.
                                     If None, the operation applies to all agents in the dataset.
@@ -2435,37 +2612,42 @@ class Dataset:
         Returns:
             self: The Dataset instance.
         """
-        #check input is valid
-        msg = 'geometry must be a shapely LineString, MultiLineString, Polygon, or MultiPolygon'
-        assert isinstance(shape, (LineString, 
-                                  MultiLineString, 
-                                  Polygon, 
-                                  MultiPolygon)), msg
+        # check input is valid
+        msg = "geometry must be a shapely LineString, MultiLineString, Polygon, or MultiPolygon"
+        assert isinstance(
+            shape, (LineString, MultiLineString, Polygon, MultiPolygon)
+        ), msg
         polylines = utils.prepare_polylines(shape)
-        #set out path
+        # set out path
         out_path = self._set_out_path(out_path)
-        #get the files to process
-        pkl_groups = list(zip(*self._get_files_tracks_to_process(agents, tracks)))
-        #resample in parallel
-        utils.pool_caller(geometry.imprint_geometry,
-                          (polylines, out_path),
-                          pkl_groups,
-                          desc,
-                          ncores)
-        #update meta
+        # get the files to process
+        pkl_groups = list(
+            zip(*self._get_files_tracks_to_process(agents, tracks))
+        )
+        # resample in parallel
+        utils.pool_caller(
+            geometry.imprint_geometry,
+            (polylines, out_path),
+            pkl_groups,
+            desc,
+            ncores,
+        )
+        # update meta
         self = self._update_meta(out_path, self.meta)
         return self
 
-    def interpolate_raster(self,
-                           ras,
-                           name,
-                           agents=None,
-                           tracks=None,
-                           ncores=1,
-                           out_path=None,
-                           method='linear',
-                           meta='Raster Values',
-                           desc='Interpolating raster to tracks'):
+    def interpolate_raster(
+        self,
+        ras,
+        name,
+        agents=None,
+        tracks=None,
+        ncores=1,
+        out_path=None,
+        method="linear",
+        meta="Raster Values",
+        desc="Interpolating raster to tracks",
+    ):
         """
         Interpolates values from a raster onto the track points, effectively assigning raster-based
         values (e.g., elevation, temperature) to each point along the tracks. This method allows for the enrichment
@@ -2499,49 +2681,57 @@ class Dataset:
         Returns:
             self: The Dataset instance.
         """
-        #assert rasterio object
-        msg = 'raster must be a rasterio object'
+        # assert rasterio object
+        msg = "raster must be a rasterio object"
         assert isinstance(ras, rio.io.DatasetReader), msg
-        #assert same crs
-        msg = 'raster must have same CRS as Dataset'
-        assert pyproj.CRS(self.meta['CRS']).equals(ras.crs), msg
-        x,_ = ras.xy([0]*ras.shape[0],range(ras.shape[0]))
-        _,y = ras.xy(range(ras.shape[1]), [0]*ras.shape[1])
-        interp = RegularGridInterpolator((x,y), 
-                                         ras.read(1),
-                                         bounds_error=False,
-                                         fill_value=np.nan,
-                                         method=method)
-        #set out path
+        # assert same crs
+        msg = "raster must have same CRS as Dataset"
+        assert pyproj.CRS(self.meta["CRS"]).equals(ras.crs), msg
+        x, _ = ras.xy([0] * ras.shape[0], range(ras.shape[0]))
+        _, y = ras.xy(range(ras.shape[1]), [0] * ras.shape[1])
+        interp = RegularGridInterpolator(
+            (x, y),
+            ras.read(1),
+            bounds_error=False,
+            fill_value=np.nan,
+            method=method,
+        )
+        # set out path
         out_path = self._set_out_path(out_path)
-        #get the files to process
-        pkl_groups = list(zip(*self._get_files_tracks_to_process(agents, tracks)))
-        #resample in parallel
-        utils.pool_caller(geometry.interpolate_raster,
-                          (interp, name, out_path),
-                          pkl_groups,
-                          desc,
-                          ncores)
-        #update meta
+        # get the files to process
+        pkl_groups = list(
+            zip(*self._get_files_tracks_to_process(agents, tracks))
+        )
+        # resample in parallel
+        utils.pool_caller(
+            geometry.interpolate_raster,
+            (interp, name, out_path),
+            pkl_groups,
+            desc,
+            ncores,
+        )
+        # update meta
         _meta = self.meta.copy()
         _meta[name] = meta
         self = self._update_meta(out_path, _meta)
         return self
 
-    def encounters(self, #first ds
-                   dataset=None, #second ds
-                   distance=0.1, #in dataset CRS units
-                   time=3600, #seconds
-                   ncores=1, 
-                   tracks0=None, #tracks in first ds
-                   tracks1=None, #tracks in second ds
-                   data_cols=[],
-                   meta_cols=[],
-                   filter_min=False, #only keep closest encounter
-                   desc='Calculating spatiotemporal encounters'):
+    def encounters(
+        self,  # first ds
+        dataset=None,  # second ds
+        distance=0.1,  # in dataset CRS units
+        time=3600,  # seconds
+        ncores=1,
+        tracks0=None,  # tracks in first ds
+        tracks1=None,  # tracks in second ds
+        data_cols=[],
+        meta_cols=[],
+        filter_min=False,  # only keep closest encounter
+        desc="Calculating spatiotemporal encounters",
+    ):
         """
-        Calculates spatiotemporal encounters between two datasets. Identifies instances where tracks 
-        come within a specified distance of each other within certain difference in time. This function can be 
+        Calculates spatiotemporal encounters between two datasets. Identifies instances where tracks
+        come within a specified distance of each other within certain difference in time. This function can be
         used for analyzing interactions or proximities between tracks.
 
         By default, dataset=None is passed, which forces the second dataset to be the same as the first. Meaning,
@@ -2576,94 +2766,98 @@ class Dataset:
         Returns:
             pd.DataFrame: Pandas DataFrame containing spatiotemporal encounters, along with requested meta_cols and data_cols.
         """
-        #if no input, self encounters
+        # if no input, self encounters
         if dataset is None:
             dataset = self.copy()
-        assert self.meta['CRS'] == dataset.meta['CRS'], 'CRS does not match between Datasets'
-        #get the two track databases
+        assert (
+            self.meta["CRS"] == dataset.meta["CRS"]
+        ), "CRS does not match between Datasets"
+        # get the two track databases
         db1 = self.tracks
         db2 = dataset.tracks
-        #reduce databases
-        keepcols = ['Start Time',
-                    'End Time', 
-                    'File',
-                    'Agent ID']
+        # reduce databases
+        keepcols = ["Start Time", "End Time", "File", "Agent ID"]
         db1 = db1[keepcols]
         db2 = db2[keepcols]
         if tracks0 is not None:
             db1 = db1.loc[tracks0]
         if tracks1 is not None:
-            db2 = db2.loc[tracks1]   
-        #find overlapping unique pairs
-        _pairs = {'Track ID_0':[],
-                  'Track ID_1':[],
-                  'Agent ID_0':[],
-                  'Agent ID_1':[],
-                  'File_0':[],
-                  'File_1':[]}
+            db2 = db2.loc[tracks1]
+        # find overlapping unique pairs
+        _pairs = {
+            "Track ID_0": [],
+            "Track ID_1": [],
+            "Agent ID_0": [],
+            "Agent ID_1": [],
+            "File_0": [],
+            "File_1": [],
+        }
         for i in range(len(db1)):
             row = db1.iloc[i]
             tid1 = row.name
-            aid1 = row['Agent ID']
-            f1 = row['File']
-            start = row['Start Time']
-            end = row['End Time'] 
-            time_ids = np.nonzero((end >= db2['Start Time'] - pd.Timedelta(f'{time}s')).values 
-                                   & (db2['End Time'] + pd.Timedelta(f'{time}s') >= start).values)[0]
+            aid1 = row["Agent ID"]
+            f1 = row["File"]
+            start = row["Start Time"]
+            end = row["End Time"]
+            time_ids = np.nonzero(
+                (end >= db2["Start Time"] - pd.Timedelta(f"{time}s")).values
+                & (db2["End Time"] + pd.Timedelta(f"{time}s") >= start).values
+            )[0]
             tid2 = db2.index[time_ids]
-            aid2 = db2['Agent ID'].iloc[time_ids]
-            f2 = db2['File'].iloc[time_ids]
-            tid1 = [tid1]*len(tid2)
-            aid1 = [aid1]*len(aid2)
-            f1 = [f1]*len(f2)
-            _pairs['Track ID_0'].extend(tid1)
-            _pairs['Track ID_1'].extend(tid2)
-            _pairs['Agent ID_0'].extend(aid1)
-            _pairs['Agent ID_1'].extend(aid2)
-            _pairs['File_0'].extend(f1)
-            _pairs['File_1'].extend(f2)
+            aid2 = db2["Agent ID"].iloc[time_ids]
+            f2 = db2["File"].iloc[time_ids]
+            tid1 = [tid1] * len(tid2)
+            aid1 = [aid1] * len(aid2)
+            f1 = [f1] * len(f2)
+            _pairs["Track ID_0"].extend(tid1)
+            _pairs["Track ID_1"].extend(tid2)
+            _pairs["Agent ID_0"].extend(aid1)
+            _pairs["Agent ID_1"].extend(aid2)
+            _pairs["File_0"].extend(f1)
+            _pairs["File_1"].extend(f2)
         pairs = pd.DataFrame(_pairs)
-        #make a unique key for all pairs
-        pairs['sorted'] = pairs.apply(lambda x: '_'.join(sorted(x)), axis=1)
-        #delete duplicated keys
-        pairs = pairs.drop_duplicates(subset='sorted')
-        #delete self encounters
-        pairs = pairs[pairs['Track ID_0'] != pairs['Track ID_1']]
-        #simplify track ids for function
-        pairs['ID_0'] = pairs['Track ID_0'].apply(lambda x: x.rsplit('_')[-1])
-        pairs['ID_1'] = pairs['Track ID_1'].apply(lambda x: x.rsplit('_')[-1])
-        #group by agent id to reduce file opens
-        grouped = pairs.groupby(['Agent ID_0', 'Agent ID_1']).agg(list)
-        grouped['File_0'] = grouped['File_0'].apply(lambda x: x[0])
-        grouped['File_1'] = grouped['File_1'].apply(lambda x: x[0])
-        #process in parallel
-        rows = utils.pool_caller(geometry.encounters,
-                                 (grouped, 
-                                  distance, 
-                                  time, 
-                                  data_cols,
-                                  meta_cols,
-                                  filter_min),
-                                 list(range(len(grouped))),
-                                 desc,
-                                 ncores)
-        #convert to geodataframe and return
+        # make a unique key for all pairs
+        pairs["sorted"] = pairs.apply(lambda x: "_".join(sorted(x)), axis=1)
+        # delete duplicated keys
+        pairs = pairs.drop_duplicates(subset="sorted")
+        # delete self encounters
+        pairs = pairs[pairs["Track ID_0"] != pairs["Track ID_1"]]
+        # simplify track ids for function
+        pairs["ID_0"] = pairs["Track ID_0"].apply(lambda x: x.rsplit("_")[-1])
+        pairs["ID_1"] = pairs["Track ID_1"].apply(lambda x: x.rsplit("_")[-1])
+        # group by agent id to reduce file opens
+        grouped = pairs.groupby(["Agent ID_0", "Agent ID_1"]).agg(list)
+        grouped["File_0"] = grouped["File_0"].apply(lambda x: x[0])
+        grouped["File_1"] = grouped["File_1"].apply(lambda x: x[0])
+        # process in parallel
+        rows = utils.pool_caller(
+            geometry.encounters,
+            (grouped, distance, time, data_cols, meta_cols, filter_min),
+            list(range(len(grouped))),
+            desc,
+            ncores,
+        )
+        # convert to geodataframe and return
         rows = utils.flatten(rows)
-        if len(rows)>0:
-            out = gp.GeoDataFrame(rows, geometry='geometry', crs=self.meta['CRS'])
+        if len(rows) > 0:
+            out = gp.GeoDataFrame(
+                rows, geometry="geometry", crs=self.meta["CRS"]
+            )
         else:
             out = gp.GeoDataFrame()
-        return out  
-         
-    def intersections(self, 
-                      dataset=None, 
-                      time=3600, 
-                      ncores=1, 
-                      tracks0=None, 
-                      tracks1=None,                   
-                      data_cols=[],
-                      meta_cols=[],
-                      desc='Calculating intersections'):
+        return out
+
+    def intersections(
+        self,
+        dataset=None,
+        time=3600,
+        ncores=1,
+        tracks0=None,
+        tracks1=None,
+        data_cols=[],
+        meta_cols=[],
+        desc="Calculating intersections",
+    ):
         """
         Calculates intersections between two datasets. Identifies instances where tracks intersect with other tracks,
         within certain difference in time. This function can be  used for analyzing interactions or proximities between tracks.
@@ -2695,102 +2889,107 @@ class Dataset:
         Returns:
             pd.DataFrame: Pandas DataFrame containing intersections, along with requested meta_cols and data_cols.
         """
-        #if no input, self intersection
+        # if no input, self intersection
         if dataset is None:
             dataset = self.copy()
-        assert self.meta['CRS'] == dataset.meta['CRS'], 'CRS does not match between DataSets'
-        #get the two track databases
+        assert (
+            self.meta["CRS"] == dataset.meta["CRS"]
+        ), "CRS does not match between DataSets"
+        # get the two track databases
         db1 = self.tracks
         db2 = dataset.tracks
-        #reduce databases
-        keepcols = ['Start Time',
-                    'End Time', 
-                    'File',
-                    'Agent ID',
-                    'geometry']
+        # reduce databases
+        keepcols = ["Start Time", "End Time", "File", "Agent ID", "geometry"]
         db1 = db1[keepcols]
         db2 = db2[keepcols]
         if tracks0 is not None:
             db1 = db1.loc[tracks0]
         if tracks1 is not None:
-            db2 = db2.loc[tracks1]   
-        #find overlapping unique pairs
-        _pairs = {'Track ID_0':[],
-                  'Track ID_1':[],
-                  'Agent ID_0':[],
-                  'Agent ID_1':[],
-                  'File_0':[],
-                  'File_1':[]}
+            db2 = db2.loc[tracks1]
+        # find overlapping unique pairs
+        _pairs = {
+            "Track ID_0": [],
+            "Track ID_1": [],
+            "Agent ID_0": [],
+            "Agent ID_1": [],
+            "File_0": [],
+            "File_1": [],
+        }
         for i in range(len(db1)):
             row = db1.iloc[i]
             tid1 = row.name
-            aid1 = row['Agent ID']
-            f1 = row['File']
-            start = row['Start Time']
-            end = row['End Time'] 
-            bbox = row['geometry']
-            time_ids = np.nonzero((end >= db2['Start Time'] - pd.Timedelta(f'{time}s')).values 
-                                   & (db2['End Time'] + pd.Timedelta(f'{time}s') >= start).values)[0]
+            aid1 = row["Agent ID"]
+            f1 = row["File"]
+            start = row["Start Time"]
+            end = row["End Time"]
+            bbox = row["geometry"]
+            time_ids = np.nonzero(
+                (end >= db2["Start Time"] - pd.Timedelta(f"{time}s")).values
+                & (db2["End Time"] + pd.Timedelta(f"{time}s") >= start).values
+            )[0]
             space_ids = np.nonzero(db2.geometry.intersects(bbox).values)[0]
             all_ids = [id for id in space_ids if id in time_ids]
             tid2 = db2.index[all_ids]
-            aid2 = db2['Agent ID'].iloc[all_ids]
-            f2 = db2['File'].iloc[all_ids]
-            tid1 = [tid1]*len(tid2)
-            aid1 = [aid1]*len(aid2)
-            f1 = [f1]*len(f2)
-            _pairs['Track ID_0'].extend(tid1)
-            _pairs['Track ID_1'].extend(tid2)
-            _pairs['Agent ID_0'].extend(aid1)
-            _pairs['Agent ID_1'].extend(aid2)
-            _pairs['File_0'].extend(f1)
-            _pairs['File_1'].extend(f2)
+            aid2 = db2["Agent ID"].iloc[all_ids]
+            f2 = db2["File"].iloc[all_ids]
+            tid1 = [tid1] * len(tid2)
+            aid1 = [aid1] * len(aid2)
+            f1 = [f1] * len(f2)
+            _pairs["Track ID_0"].extend(tid1)
+            _pairs["Track ID_1"].extend(tid2)
+            _pairs["Agent ID_0"].extend(aid1)
+            _pairs["Agent ID_1"].extend(aid2)
+            _pairs["File_0"].extend(f1)
+            _pairs["File_1"].extend(f2)
         pairs = pd.DataFrame(_pairs)
-        #make a unique key for all pairs
-        pairs['sorted'] = pairs.apply(lambda x: '_'.join(sorted(x)), axis=1)
-        #delete duplicated keys
-        pairs = pairs.drop_duplicates(subset='sorted')
-        #delete self encounters
-        pairs = pairs[pairs['Track ID_0'] != pairs['Track ID_1']]
-        #simplify track ids for function
-        pairs['ID_0'] = pairs['Track ID_0'].apply(lambda x: x.rsplit('_')[-1])
-        pairs['ID_1'] = pairs['Track ID_1'].apply(lambda x: x.rsplit('_')[-1])
-        #group by agent id to reduce file opens
-        grouped = pairs.groupby(['Agent ID_0', 'Agent ID_1']).agg(list)
-        grouped['File_0'] = grouped['File_0'].apply(lambda x: x[0])
-        grouped['File_1'] = grouped['File_1'].apply(lambda x: x[0])
-        #process in parallel
-        rows = utils.pool_caller(geometry.intersections,
-                                 (grouped, 
-                                  time, 
-                                  data_cols,
-                                  meta_cols),
-                                 list(range(len(grouped))),
-                                 desc,
-                                 ncores)
-        #convert to geodataframe and return
+        # make a unique key for all pairs
+        pairs["sorted"] = pairs.apply(lambda x: "_".join(sorted(x)), axis=1)
+        # delete duplicated keys
+        pairs = pairs.drop_duplicates(subset="sorted")
+        # delete self encounters
+        pairs = pairs[pairs["Track ID_0"] != pairs["Track ID_1"]]
+        # simplify track ids for function
+        pairs["ID_0"] = pairs["Track ID_0"].apply(lambda x: x.rsplit("_")[-1])
+        pairs["ID_1"] = pairs["Track ID_1"].apply(lambda x: x.rsplit("_")[-1])
+        # group by agent id to reduce file opens
+        grouped = pairs.groupby(["Agent ID_0", "Agent ID_1"]).agg(list)
+        grouped["File_0"] = grouped["File_0"].apply(lambda x: x[0])
+        grouped["File_1"] = grouped["File_1"].apply(lambda x: x[0])
+        # process in parallel
+        rows = utils.pool_caller(
+            geometry.intersections,
+            (grouped, time, data_cols, meta_cols),
+            list(range(len(grouped))),
+            desc,
+            ncores,
+        )
+        # convert to geodataframe and return
         rows = utils.flatten(rows)
-        if len(rows)>0:
-            out = gp.GeoDataFrame(rows, geometry='geometry', crs=self.meta['CRS'])
+        if len(rows) > 0:
+            out = gp.GeoDataFrame(
+                rows, geometry="geometry", crs=self.meta["CRS"]
+            )
         else:
             out = gp.GeoDataFrame()
-        return out   
-    
-    def proximity_to_object(self, 
-                            shapely_object, 
-                            agents=None,
-                            tracks=None, 
-                            data_cols=[],
-                            meta_cols=[],
-                            ncores=1, 
-                            desc='Calculating proximities to object'):
+        return out
+
+    def proximity_to_object(
+        self,
+        shapely_object,
+        agents=None,
+        tracks=None,
+        data_cols=[],
+        meta_cols=[],
+        ncores=1,
+        desc="Calculating proximities to object",
+    ):
         """
         Calculates the minimum proximity of tracks to a specified geometric object. This object can be a
         shapely Point, MultiPoint, LineString, MultiLineString, Polygon, or MultiPolygon. It can also be
         a Nx2 numpy array containing x,y points that represent the former.
-         
-        The minimum proxixity between tracks and the object may not necessarily be points that fall on either of 
-        the original shapes. For example, if the object is a point, the closest proximity may be somewhere in the 
+
+        The minimum proxixity between tracks and the object may not necessarily be points that fall on either of
+        the original shapes. For example, if the object is a point, the closest proximity may be somewhere in the
         middle of one of the track's segments. This is similar to the shapely.ops.nearest_points:
 
         https://shapely.readthedocs.io/en/stable/manual.html#shapely.ops.nearest_points
@@ -2812,37 +3011,43 @@ class Dataset:
         Returns:
             DataFrame: A pandas DataFrame containing the minimum proximities, along with the requested meta_cols and data_cols.
         """
-        #get the files to process
-        pkl_groups = list(zip(*self._get_files_tracks_to_process(agents, tracks)))
-        #prepare geometry
+        # get the files to process
+        pkl_groups = list(
+            zip(*self._get_files_tracks_to_process(agents, tracks))
+        )
+        # prepare geometry
         shapes = utils.prepare_polylines(shapely_object)
-        #get proximities in parallel
-        rows = utils.pool_caller(geometry.proximity_to_object,
-                                 (shapes, data_cols, meta_cols),
-                                 pkl_groups,
-                                 desc,
-                                 ncores)
-        #flatten and return
+        # get proximities in parallel
+        rows = utils.pool_caller(
+            geometry.proximity_to_object,
+            (shapes, data_cols, meta_cols),
+            pkl_groups,
+            desc,
+            ncores,
+        )
+        # flatten and return
         rows = utils.flatten(rows)
         out = pd.DataFrame(rows)
         return out
-    
-    def proximities(self,
-                    dataset=None,
-                    tracks0=None, 
-                    tracks1=None,
-                    data_cols=[],
-                    meta_cols=[],
-                    ncores=1, 
-                    bins=None, 
-                    relative=False,
-                    desc='Calculating track proximities'):
+
+    def proximities(
+        self,
+        dataset=None,
+        tracks0=None,
+        tracks1=None,
+        data_cols=[],
+        meta_cols=[],
+        ncores=1,
+        bins=None,
+        relative=False,
+        desc="Calculating track proximities",
+    ):
         """
         ***Note, this method assumes Datset.resample_time_global has already been run. If the tracks aren't on the same
         time axis, this will not work***
 
-        Calculates proximities between tracks. This analysis can help identify close encounters, common pathways, 
-        or general spatiotemporal relationships between moving entities represented by the tracks. 
+        Calculates proximities between tracks. This analysis can help identify close encounters, common pathways,
+        or general spatiotemporal relationships between moving entities represented by the tracks.
 
         By default, dataset=None is passed, which forces the second dataset to be the same as the first. Meaning,
         the default is to find the proximity of tracks inside the same Dataset; this is likely the most common application.
@@ -2850,7 +3055,7 @@ class Dataset:
         By passing a list of meta_cols or data_cols, you can also maintain metadata about the interactions (e.g. speed, coursing)
         which can facilitate more complex analyses with the data.
 
-        If bins is left as None, the output will be the closest point of approach (CPA) between each pair of tracks. 
+        If bins is left as None, the output will be the closest point of approach (CPA) between each pair of tracks.
 
         If bins is not None, it must be a list of distance bins. Then, the output will be the amount of time spent
         in each distance between, for each pair of tracks.
@@ -2881,111 +3086,118 @@ class Dataset:
         Returns:
             DataFrame: A pandas DataFrame containing the proximity output, depending on the value of bins and relative kwargs.
         """
-        print('Proximity analysis assumes that self.resample_time_global has already been run, '\
-            'if not the results will be invalid or the function may fail')
-        #if no input, self encounters
+        print(
+            "Proximity analysis assumes that self.resample_time_global has already been run, "
+            "if not the results will be invalid or the function may fail"
+        )
+        # if no input, self encounters
         if dataset is None:
             dataset = self.copy()
-        assert self.meta['CRS'] == dataset.meta['CRS'], 'CRS does not match between Datasets'
-        #ensure relative is False if no bins
+        assert (
+            self.meta["CRS"] == dataset.meta["CRS"]
+        ), "CRS does not match between Datasets"
+        # ensure relative is False if no bins
         if bins is None:
             relative = False
-        #get the two track databases
+        # get the two track databases
         db1 = self.tracks
         db2 = dataset.tracks
-        #reduce databases
-        keepcols = ['Start Time',
-                    'End Time', 
-                    'File',
-                    'Agent ID']
+        # reduce databases
+        keepcols = ["Start Time", "End Time", "File", "Agent ID"]
         db1 = db1[keepcols]
         db2 = db2[keepcols]
         if tracks0 is not None:
             db1 = db1.loc[tracks0]
         if tracks1 is not None:
-            db2 = db2.loc[tracks1]   
-        #find overlapping unique pairs
-        _pairs = {'Track ID_0':[],
-                  'Track ID_1':[],
-                  'Agent ID_0':[],
-                  'Agent ID_1':[],
-                  'File_0':[],
-                  'File_1':[]}
+            db2 = db2.loc[tracks1]
+        # find overlapping unique pairs
+        _pairs = {
+            "Track ID_0": [],
+            "Track ID_1": [],
+            "Agent ID_0": [],
+            "Agent ID_1": [],
+            "File_0": [],
+            "File_1": [],
+        }
         for i in range(len(db1)):
             row = db1.iloc[i]
             tid1 = row.name
-            aid1 = row['Agent ID']
-            f1 = row['File']
-            start = row['Start Time']
-            end = row['End Time'] 
-            time_ids = np.nonzero((end >= db2['Start Time']).values 
-                                   & (db2['End Time'] >= start).values)[0]
+            aid1 = row["Agent ID"]
+            f1 = row["File"]
+            start = row["Start Time"]
+            end = row["End Time"]
+            time_ids = np.nonzero(
+                (end >= db2["Start Time"]).values
+                & (db2["End Time"] >= start).values
+            )[0]
             tid2 = db2.index[time_ids]
-            aid2 = db2['Agent ID'].iloc[time_ids]
-            f2 = db2['File'].iloc[time_ids]
-            tid1 = [tid1]*len(tid2)
-            aid1 = [aid1]*len(aid2)
-            f1 = [f1]*len(f2)
-            _pairs['Track ID_0'].extend(tid1)
-            _pairs['Track ID_1'].extend(tid2)
-            _pairs['Agent ID_0'].extend(aid1)
-            _pairs['Agent ID_1'].extend(aid2)
-            _pairs['File_0'].extend(f1)
-            _pairs['File_1'].extend(f2)
+            aid2 = db2["Agent ID"].iloc[time_ids]
+            f2 = db2["File"].iloc[time_ids]
+            tid1 = [tid1] * len(tid2)
+            aid1 = [aid1] * len(aid2)
+            f1 = [f1] * len(f2)
+            _pairs["Track ID_0"].extend(tid1)
+            _pairs["Track ID_1"].extend(tid2)
+            _pairs["Agent ID_0"].extend(aid1)
+            _pairs["Agent ID_1"].extend(aid2)
+            _pairs["File_0"].extend(f1)
+            _pairs["File_1"].extend(f2)
         pairs = pd.DataFrame(_pairs)
-        #make a unique key for all pairs
-        pairs['sorted'] = pairs.apply(lambda x: '_'.join(sorted(x)), axis=1)
-        #delete duplicated keys
-        pairs = pairs.drop_duplicates(subset='sorted')
-        #delete self encounters
-        pairs = pairs[pairs['Track ID_0'] != pairs['Track ID_1']]
-        #simplify track ids for function
-        pairs['ID_0'] = pairs['Track ID_0'].apply(lambda x: x.rsplit('_')[-1])
-        pairs['ID_1'] = pairs['Track ID_1'].apply(lambda x: x.rsplit('_')[-1])
-        #group by agent id to reduce file opens
-        grouped = pairs.groupby(['Agent ID_0', 'Agent ID_1']).agg(list)
-        grouped['File_0'] = grouped['File_0'].apply(lambda x: x[0])
-        grouped['File_1'] = grouped['File_1'].apply(lambda x: x[0])
-        #process in parallel
-        rows = utils.pool_caller(geometry.proximities,
-                                 (grouped,
-                                  bins,
-                                  relative,
-                                  data_cols,
-                                  meta_cols),
-                                 list(range(len(grouped))),
-                                 desc,
-                                 ncores)
-        #convert to dataframe
+        # make a unique key for all pairs
+        pairs["sorted"] = pairs.apply(lambda x: "_".join(sorted(x)), axis=1)
+        # delete duplicated keys
+        pairs = pairs.drop_duplicates(subset="sorted")
+        # delete self encounters
+        pairs = pairs[pairs["Track ID_0"] != pairs["Track ID_1"]]
+        # simplify track ids for function
+        pairs["ID_0"] = pairs["Track ID_0"].apply(lambda x: x.rsplit("_")[-1])
+        pairs["ID_1"] = pairs["Track ID_1"].apply(lambda x: x.rsplit("_")[-1])
+        # group by agent id to reduce file opens
+        grouped = pairs.groupby(["Agent ID_0", "Agent ID_1"]).agg(list)
+        grouped["File_0"] = grouped["File_0"].apply(lambda x: x[0])
+        grouped["File_1"] = grouped["File_1"].apply(lambda x: x[0])
+        # process in parallel
+        rows = utils.pool_caller(
+            geometry.proximities,
+            (grouped, bins, relative, data_cols, meta_cols),
+            list(range(len(grouped))),
+            desc,
+            ncores,
+        )
+        # convert to dataframe
         if relative:
-            out = pd.concat([pd.DataFrame(r) for r in rows]).reset_index(drop=True)
-            out = out.groupby('Time').agg(max).reset_index()
+            out = pd.concat([pd.DataFrame(r) for r in rows]).reset_index(
+                drop=True
+            )
+            out = out.groupby("Time").agg(max).reset_index()
         else:
             rows = utils.flatten(rows)
             out = pd.DataFrame(rows)
         return out
-    
-    def lateral_distribution(self,
-                             start,
-                             end,
-                             split=True,
-                             spacing=100,
-                             n_slices=0,
-                             agents=None,
-                             tracks=None,
-                             ncores=1,
-                             polygon=None,
-                             density=True,
-                             bins=100,
-                             meta_cols=[],
-                             data_cols=[],
-                             desc='Calculating lateral distributions at slices'):
+
+    def lateral_distribution(
+        self,
+        start,
+        end,
+        split=True,
+        spacing=100,
+        n_slices=0,
+        agents=None,
+        tracks=None,
+        ncores=1,
+        polygon=None,
+        density=True,
+        bins=100,
+        meta_cols=[],
+        data_cols=[],
+        desc="Calculating lateral distributions at slices",
+    ):
         """
         Analyzes the lateral distribution of tracks across specified slices/cross-sections of the data.
-         his method can also split tracks going to/from the direction along start to end to separate 
+         his method can also split tracks going to/from the direction along start to end to separate
         opposing "lanes" of traffic.
-        
-        Slices are taken along a line from start to end, with either n_slices or spacing defining where the slices fall. 
+
+        Slices are taken along a line from start to end, with either n_slices or spacing defining where the slices fall.
         You can specify the lateral distribution bin width, and whether to return a relative (0-1) or absolute probability
         distribution function.
 
@@ -3018,75 +3230,84 @@ class Dataset:
         Returns:
             DataFrame: A pandas DataFrame containing the distribution data across slices, along with the requested meta_cols and data_cols.
         """
-        #length/slope of arc
-        dist = (np.diff(np.array([start, end]), axis=0)**2).sum()**0.5
-        dy, dx = ((end[1] - start[1])/dist , (end[0] - start[0])/dist)
-        #longitudinal slice locations
-        long, xy = utils.longitudinal_slices(start, 
-                                             end, 
-                                             n_slices, 
-                                             spacing, 
-                                             dist)
-        #get the files to process
-        pkl_groups = list(zip(*self._get_files_tracks_to_process(agents, tracks)))
-        #process in parallel
-        dfs = utils.pool_caller(geometry.lateral_distribution,
-                                (long, xy, dy, dx, meta_cols, data_cols),
-                                pkl_groups,
-                                desc,
-                                ncores)
-        #flatten and turn into dataframe
-        df = pd.concat([_df for _df in dfs if len(_df)>0]).reset_index(drop=True)
-        #clip to polygon
+        # length/slope of arc
+        dist = (np.diff(np.array([start, end]), axis=0) ** 2).sum() ** 0.5
+        dy, dx = ((end[1] - start[1]) / dist, (end[0] - start[0]) / dist)
+        # longitudinal slice locations
+        long, xy = utils.longitudinal_slices(
+            start, end, n_slices, spacing, dist
+        )
+        # get the files to process
+        pkl_groups = list(
+            zip(*self._get_files_tracks_to_process(agents, tracks))
+        )
+        # process in parallel
+        dfs = utils.pool_caller(
+            geometry.lateral_distribution,
+            (long, xy, dy, dx, meta_cols, data_cols),
+            pkl_groups,
+            desc,
+            ncores,
+        )
+        # flatten and turn into dataframe
+        df = pd.concat([_df for _df in dfs if len(_df) > 0]).reset_index(
+            drop=True
+        )
+        # clip to polygon
         if polygon is not None:
             polygon, edges = utils.format_polygon(polygon)
-            mask = np.logical_or(*inpoly2(df[['TrackX', 'TrackY']].values, 
-                                          polygon, 
-                                          edges))
+            mask = np.logical_or(
+                *inpoly2(df[["TrackX", "TrackY"]].values, polygon, edges)
+            )
             df = df.loc[mask]
-        #groupby
+        # groupby
         if split:
-            grouper = ['Longitudinal Distance', 'Direction']
+            grouper = ["Longitudinal Distance", "Direction"]
         else:
-            grouper = ['Longitudinal Distance']
+            grouper = ["Longitudinal Distance"]
         grouped = df.groupby(grouper)[df.columns].agg(list)
-        #drop and format couple columns
-        grouped.drop(columns=['Longitudinal Distance',
-                              'Direction'], inplace=True)
-        grouped['SliceX'] = grouped['SliceX'].apply(lambda x: x[0])
-        grouped['SliceY'] = grouped['SliceY'].apply(lambda x: x[0])
-        #get global min/max
-        global_min = grouped['Lateral Distance'].explode().min()
-        global_max = grouped['Lateral Distance'].explode().max()
-        #create global bin edges and add to df
+        # drop and format couple columns
+        grouped.drop(
+            columns=["Longitudinal Distance", "Direction"], inplace=True
+        )
+        grouped["SliceX"] = grouped["SliceX"].apply(lambda x: x[0])
+        grouped["SliceY"] = grouped["SliceY"].apply(lambda x: x[0])
+        # get global min/max
+        global_min = grouped["Lateral Distance"].explode().min()
+        global_max = grouped["Lateral Distance"].explode().max()
+        # create global bin edges and add to df
         edges = utils.range_to_edges(global_min, global_max, bins)
-        grouped['Bins'] = [edges]*len(grouped)
-        #add frequency
-        grouped['Frequency'] = grouped.apply(lambda row: np.histogram(row['Lateral Distance'],
-                                                                      bins=row['Bins'],
-                                                                      density=False)[0], 
-                                             axis=1)
-        #if density, divide by total number of entries
+        grouped["Bins"] = [edges] * len(grouped)
+        # add frequency
+        grouped["Frequency"] = grouped.apply(
+            lambda row: np.histogram(
+                row["Lateral Distance"], bins=row["Bins"], density=False
+            )[0],
+            axis=1,
+        )
+        # if density, divide by total number of entries
         if density:
-            grouped['Frequency'] /= grouped['Lateral Distance'].apply(len)
-        #return
+            grouped["Frequency"] /= grouped["Lateral Distance"].apply(len)
+        # return
         return grouped
-    
-    def time_in_polygon(self, 
-                        polygon,
-                        agents=None,
-                        tracks=None,
-                        meta_cols=[],
-                        data_cols=[],
-                        desc='Computing time spent in polygon',
-                        ncores=1):
+
+    def time_in_polygon(
+        self,
+        polygon,
+        agents=None,
+        tracks=None,
+        meta_cols=[],
+        data_cols=[],
+        desc="Computing time spent in polygon",
+        ncores=1,
+    ):
         """
         Computes the time spent and distance travelled by tracks inside a specified polygonal area. This function is useful
         for analyzing spatial usage, such as habitat utilization, restricted area compliance, or general movement patterns
         within specific geographic boundaries. The analysis can help identify which agents or tracks spend time in the
         area of interest and quantify that time.
 
-        This is best used in conjunction with Dataset.imprint_geometry, as it can imprint the polygon outline into 
+        This is best used in conjunction with Dataset.imprint_geometry, as it can imprint the polygon outline into
         the actual tracks, thereby making the time spent and distance travelled estimates more accurate.
 
         The polygon can be a shapely Polygon, or Nx2 numpy defining a polygon.
@@ -3111,37 +3332,43 @@ class Dataset:
             DataFrame: A pandas DataFrame containing the calculated times spent and distances travelled within the polygon
                     for each track, along with any specified meta_cols and data_cols.
         """
-        #get polygon
+        # get polygon
         polygon, edges = utils.format_polygon(polygon)
-        #get the files to process
-        pkl_groups = list(zip(*self._get_files_tracks_to_process(agents, tracks)))
-        #compute in parallel
-        rows = utils.pool_caller(geometry.time_in_polygon,
-                                (polygon, edges, meta_cols, data_cols),
-                                pkl_groups,
-                                desc,
-                                ncores)
-        #flatten and turn into dataframe
+        # get the files to process
+        pkl_groups = list(
+            zip(*self._get_files_tracks_to_process(agents, tracks))
+        )
+        # compute in parallel
+        rows = utils.pool_caller(
+            geometry.time_in_polygon,
+            (polygon, edges, meta_cols, data_cols),
+            pkl_groups,
+            desc,
+            ncores,
+        )
+        # flatten and turn into dataframe
         rows = utils.flatten(rows)
         df = pd.DataFrame(rows)
         return df
-    
-    def generate_flow_map(self,
-                          polygons,
-                          characteristic_col=None,
-                          flow_col='Graph Node',
-                          agents=None,
-                          tracks=None,
-                          ncores=1,
-                          desc='Generating flow map from polygons'):
+
+    def generate_flow_map(
+        self,
+        polygons,
+        characteristic_col=None,
+        flow_col="Graph Node",
+        agents=None,
+        tracks=None,
+        ncores=1,
+        desc="Generating flow map from polygons",
+    ):
         """
         Generates a flow map based on movement or connectivity between specified polygonal areas. This function is
         useful for visualizing movement patterns, such as migration routes, traffic flows, or general movements of
         agents through different regions. The flow map can highlight areas of high connectivity or movement concentration,
         providing insights into spatial dynamics within the dataset from a macroscopic perspective.
 
-        This method assumes that you have already ran the Dataset.classify_in_polygons method to classify the 
-        tracks inside the polygons GeoDataFrame. The flow_col kwarg is the column that was produced when running 
+        This method assumes that you have already ran the Dataset.classify_in_polygons method to classify the
+        tracks inside the polygons GeoDataFrame. The flow_col kwarg is the column that was produced when running
         Dataset.classify_in_polygons.
 
         This method works by collecting all of the movements from polygon to polygon in the track data. Then, the movements
@@ -3170,56 +3397,61 @@ class Dataset:
             GeoDataFrame: A geopandas GeoDataFrame containing LineStrings representing the unique edges of the flow map,
                          along with their volume.
         """
-        #make sure it is proper format
-        msg = 'Polygons must be gp.GeoDataFrame with Code, X, Y columns'
+        # make sure it is proper format
+        msg = "Polygons must be gp.GeoDataFrame with Code, X, Y columns"
         assert isinstance(polygons, gp.GeoDataFrame), msg
-        assert all([c in polygons.columns for c in ['Code','X','Y']]), msg
-        #get the files to process
-        pkl_groups = list(zip(*self._get_files_tracks_to_process(agents, tracks)))
-        #compute in parallel
-        rows = utils.pool_caller(geometry.generate_flow_map,
-                                (characteristic_col, 
-                                 flow_col),
-                                pkl_groups,
-                                desc,
-                                ncores)
-        #flatten and convert to dataframe
+        assert all([c in polygons.columns for c in ["Code", "X", "Y"]]), msg
+        # get the files to process
+        pkl_groups = list(
+            zip(*self._get_files_tracks_to_process(agents, tracks))
+        )
+        # compute in parallel
+        rows = utils.pool_caller(
+            geometry.generate_flow_map,
+            (characteristic_col, flow_col),
+            pkl_groups,
+            desc,
+            ncores,
+        )
+        # flatten and convert to dataframe
         rows = utils.flatten(rows)
         df = pd.DataFrame(rows)
-        df = df.groupby(['Start', 'End']).agg(list)
-        df['Volume'] = df['Track ID'].apply(len)
-        #add the linestrings
-        keys = polygons['Code'].values
-        vals = polygons[['X','Y']].values
+        df = df.groupby(["Start", "End"]).agg(list)
+        df["Volume"] = df["Track ID"].apply(len)
+        # add the linestrings
+        keys = polygons["Code"].values
+        vals = polygons[["X", "Y"]].values
         points = dict(zip(keys, vals))
         geo = []
         for idx in df.index:
             line = LineString([points[idx[0]], points[idx[1]]])
             geo.append(line)
-        #turn to gdf
+        # turn to gdf
         gdf = gp.GeoDataFrame(df, geometry=geo, crs=polygons.crs)
-        #add some properties
-        gdf['Length'] = gdf.geometry.length
+        # add some properties
+        gdf["Length"] = gdf.geometry.length
         dx = gdf.geometry.apply(lambda x: x.coords[-1][0] - x.coords[0][0])
         dy = gdf.geometry.apply(lambda x: x.coords[-1][1] - x.coords[0][1])
-        gdf['Direction'] = np.degrees(np.arctan2(dx, dy)) % 360
+        gdf["Direction"] = np.degrees(np.arctan2(dx, dy)) % 360
         return gdf.reset_index()
 
-    def reduce_to_flow_map(self,
-                          polygons,
-                          characteristic_col=None,
-                          flow_col='Graph Node',
-                          agents=None,
-                          tracks=None,
-                          ncores=1,
-                          out_path=None,
-                          desc='Generating flow map from polygons'):
+    def reduce_to_flow_map(
+        self,
+        polygons,
+        characteristic_col=None,
+        flow_col="Graph Node",
+        agents=None,
+        tracks=None,
+        ncores=1,
+        out_path=None,
+        desc="Generating flow map from polygons",
+    ):
         """
         This works the same way as Dataset.generate_flow_map, but instead the tracks are actually
         reduced to their flow map representation.
 
-        This method assumes that you have already ran the Dataset.classify_in_polygons method to classify the 
-        tracks inside the polygons GeoDataFrame. The flow_col kwarg is the column that was produced when running 
+        This method assumes that you have already ran the Dataset.classify_in_polygons method to classify the
+        tracks inside the polygons GeoDataFrame. The flow_col kwarg is the column that was produced when running
         Dataset.classify_in_polygons.
 
         This method works by routing each track through the polygons using the flow_col data, and then reducing
@@ -3245,55 +3477,58 @@ class Dataset:
         Returns:
             self: The Dataset instance.
         """
-        #set out path
+        # set out path
         out_path = self._set_out_path(out_path)
-        #make sure it is proper format
-        msg = 'Polygons must be gp.GeoDataFrame with Code, X, Y columns'
+        # make sure it is proper format
+        msg = "Polygons must be gp.GeoDataFrame with Code, X, Y columns"
         assert isinstance(polygons, gp.GeoDataFrame), msg
-        assert all([c in polygons.columns for c in ['Code','X','Y']]), msg
-        #get the files to process
-        pkl_groups = list(zip(*self._get_files_tracks_to_process(agents, tracks)))
-        #make point lookup
-        keys = polygons['Code'].values
-        vals = polygons[['X','Y']].values
+        assert all([c in polygons.columns for c in ["Code", "X", "Y"]]), msg
+        # get the files to process
+        pkl_groups = list(
+            zip(*self._get_files_tracks_to_process(agents, tracks))
+        )
+        # make point lookup
+        keys = polygons["Code"].values
+        vals = polygons[["X", "Y"]].values
         points = dict(zip(keys, vals))
-        #compute in parallel
-        utils.pool_caller(geometry.reduce_to_flow_map,
-                        (characteristic_col, 
-                        flow_col,
-                        out_path,
-                        points),
-                        pkl_groups,
-                        desc,
-                        ncores)
-        #update meta
+        # compute in parallel
+        utils.pool_caller(
+            geometry.reduce_to_flow_map,
+            (characteristic_col, flow_col, out_path, points),
+            pkl_groups,
+            desc,
+            ncores,
+        )
+        # update meta
         self = self._update_meta(out_path, self.meta)
         return self
-    
-    def route_through_raster(self, 
-                             ras,
-                             agents=None,
-                             tracks=None,
-                             out_path=None,
-                             end=None,
-                             desc='Routing tracks through raster',
-                             ncores=1,
-                             **kwargs):
+
+    def route_through_raster(
+        self,
+        ras,
+        agents=None,
+        tracks=None,
+        out_path=None,
+        end=None,
+        desc="Routing tracks through raster",
+        ncores=1,
+        **kwargs,
+    ):
         """
         Routes tracks through a cost raster using a least cost path algorithm. This is a thin wrapper
         over skimage.graph.route_through_array, and will accept any of the kwargs the original function
         will accept:
 
-        https://scikit-image.org/docs/stable/api/skimage.graph.html#skimage.graph.route_through_array 
+        https://scikit-image.org/docs/stable/api/skimage.graph.html#skimage.graph.route_through_array
 
         This can be used to generate synthetic movements through obstacle arrays, or to very simply
         model the movement of agents through some form of force/cost/resistance field.
 
         The method only applies to tracks that intersect with the outline of the raster.
 
-        The simplest case is when a track passes through the raster completely. In this case, the 
+        The simplest case is when a track passes through the raster completely. In this case, the
         track is routed from the entrance to the exit of the raster outline.
-        
+
         The first edge case is when a track starts inside the raster and leaves. In this case, the
         track is routed from the first point on the track to the exit of the raster outline.
 
@@ -3308,7 +3543,7 @@ class Dataset:
         algorithm is more geared towards geometric/spatial rerouting.
 
         If you pass a directory for the out_path kwarg, the *.tracks files will be saved to this directory,
-        and self.data_path will be changed as well. If you pass None, it simply saves the *.tracks files 
+        and self.data_path will be changed as well. If you pass None, it simply saves the *.tracks files
         in the original self.data_path location.
 
         Args:
@@ -3329,14 +3564,16 @@ class Dataset:
         Returns:
             self: The Dataset instance.
         """
-        #assert rasterio object
-        msg = 'raster must be a rasterio object'
+        # assert rasterio object
+        msg = "raster must be a rasterio object"
         assert isinstance(ras, rio.io.DatasetReader), msg
-        #set out path
+        # set out path
         out_path = self._set_out_path(out_path)
-        #get the raster info
+        # get the raster info
         b = ras.bounds
-        polygon, edges = utils.format_polygon(box(b.left, b.bottom, b.right, b.top))
+        polygon, edges = utils.format_polygon(
+            box(b.left, b.bottom, b.right, b.top)
+        )
         array = ras.read(1)
         transform = ras.transform
         width = ras.width
@@ -3344,41 +3581,41 @@ class Dataset:
         row_inds, col_inds = np.indices((height, width))
         x_coords, y_coords = transform * (col_inds, row_inds)
         coords = np.dstack([x_coords, y_coords])
-        #get the files to process
-        pkl_groups = list(zip(*self._get_files_tracks_to_process(agents, tracks)))
-        #compute in parallel
-        utils.pool_caller(geometry.route_through_raster,
-                          (array, 
-                           polygon, 
-                           edges, 
-                           coords,
-                           end,
-                           out_path,
-                           kwargs),
-                          pkl_groups,
-                          desc,
-                          ncores)
-        #update meta
+        # get the files to process
+        pkl_groups = list(
+            zip(*self._get_files_tracks_to_process(agents, tracks))
+        )
+        # compute in parallel
+        utils.pool_caller(
+            geometry.route_through_raster,
+            (array, polygon, edges, coords, end, out_path, kwargs),
+            pkl_groups,
+            desc,
+            ncores,
+        )
+        # update meta
         self = self._update_meta(out_path, self.meta)
         return self
 
     ############################################################################
-    #CLUSTERING
+    # CLUSTERING
     ############################################################################
 
     # def MiniBatchKMeans(self, ncores)
 
     ############################################################################
-    #CLASSIFYING
+    # CLASSIFYING
     ############################################################################
-                
-    def classify_in_polygon(self,
-                            polygon,
-                            agents=None,
-                            tracks=None, 
-                            ncores=1, 
-                            code=16,
-                            desc='Classifying tracks inside polygon'):
+
+    def classify_in_polygon(
+        self,
+        polygon,
+        agents=None,
+        tracks=None,
+        ncores=1,
+        code=16,
+        desc="Classifying tracks inside polygon",
+    ):
         """
         Classifies points along tracks True if they fall on/within a specified polygon,
         and False if they do not. This classification is stored in a boolean column in the track data.
@@ -3393,37 +3630,42 @@ class Dataset:
                                     of certain tracks. If None, the operation applies to tracks related to the specified
                                     agents or all tracks if no agents are specified.
             ncores (int, optional): The number of processing cores to use for the classification operation. Defaults to 1.
-            code (int, optional): A numerical code to be used for the resulting boolean column. E.g. if code=16, then 
+            code (int, optional): A numerical code to be used for the resulting boolean column. E.g. if code=16, then
                                  the output column is Code16. Defaults to 16. Do not use 0.
             desc (str, optional): A brief description of the operation. Defaults to 'Classifying tracks inside polygon'.
 
         Returns:
             self: The Dataset instance.
         """
-        #get polygon
+        # get polygon
         polygon, edges = utils.format_polygon(polygon)
-        #get the files to process
-        pkl_groups = list(zip(*self._get_files_tracks_to_process(agents, tracks)))
-        #resample in parallel
-        utils.pool_caller(classify.classify_in_polygon,
-                          (polygon, edges, code),
-                          pkl_groups,
-                          desc,
-                          ncores)
-        #update meta
-        meta = 'Inside Polygon'
-        self.meta[f'Code{code}'] = meta
+        # get the files to process
+        pkl_groups = list(
+            zip(*self._get_files_tracks_to_process(agents, tracks))
+        )
+        # resample in parallel
+        utils.pool_caller(
+            classify.classify_in_polygon,
+            (polygon, edges, code),
+            pkl_groups,
+            desc,
+            ncores,
+        )
+        # update meta
+        meta = "Inside Polygon"
+        self.meta[f"Code{code}"] = meta
         return self
 
-    
-    def classify_in_polygons(self,
-                            polygons,
-                            agents=None,
-                            tracks=None, 
-                            ncores=1,
-                            to_codes=False,
-                            name='Polygon',
-                            desc='Classifying tracks inside polygons'):
+    def classify_in_polygons(
+        self,
+        polygons,
+        agents=None,
+        tracks=None,
+        ncores=1,
+        to_codes=False,
+        name="Polygon",
+        desc="Classifying tracks inside polygons",
+    ):
         """
         Classifies points if they fall om/within user defined polygons.
 
@@ -3441,7 +3683,7 @@ class Dataset:
         behaviour as Dataset.classify_in_polygon, just with more than 1 polygon.
 
         Args:
-            polygons: geopandas GeoDataFrame with a series of shapely Polygons for geometry, and a Code column with unique 
+            polygons: geopandas GeoDataFrame with a series of shapely Polygons for geometry, and a Code column with unique
                      integers for each polygon. Do not use 0 as a Code value.
             agents (list, optional): A list of agent IDs to be included in the classification. If None, the classification
                                     will consider all agents in the dataset.
@@ -3459,31 +3701,37 @@ class Dataset:
         Returns:
             self: The Dataset instance.
         """
-        #copy
+        # copy
         polygons = polygons.copy()
-        #get polygons
-        polygons['polys'] = polygons.geometry.apply(utils.format_polygon)
-        #get the files to process
-        pkl_groups = list(zip(*self._get_files_tracks_to_process(agents, tracks)))
-        #resample in parallel
-        utils.pool_caller(classify.classify_in_polygons,
-                          (polygons, to_codes, name),
-                          pkl_groups,
-                          desc,
-                          ncores)
-        #update meta
-        meta='Inside Polygon'
-        for code in polygons['Code'].values:
-            self.meta[f'Code{code}'] = meta
+        # get polygons
+        polygons["polys"] = polygons.geometry.apply(utils.format_polygon)
+        # get the files to process
+        pkl_groups = list(
+            zip(*self._get_files_tracks_to_process(agents, tracks))
+        )
+        # resample in parallel
+        utils.pool_caller(
+            classify.classify_in_polygons,
+            (polygons, to_codes, name),
+            pkl_groups,
+            desc,
+            ncores,
+        )
+        # update meta
+        meta = "Inside Polygon"
+        for code in polygons["Code"].values:
+            self.meta[f"Code{code}"] = meta
         return self
-    
-    def classify_toward_point(self: 'Dataset',
-                            point: Point,
-                            agents: list | None = None,
-                            tracks: list | None = None, 
-                            ncores: int =1, 
-                            code: int =16,
-                            desc: str ='Classifying tracks toward point'):
+
+    def classify_toward_point(
+        self: "Dataset",
+        point: Point,
+        agents: list | None = None,
+        tracks: list | None = None,
+        ncores: int = 1,
+        code: int = 16,
+        desc: str = "Classifying tracks toward point",
+    ):
         """
         Classifies tracks True if they head towards a given point, and False if they do not. This classification is stored in a boolean column in the track data.
 
@@ -3495,35 +3743,41 @@ class Dataset:
                                     of certain tracks. If None, the operation applies to tracks related to the specified
                                     agents or all tracks if no agents are specified.
             ncores (int, optional): The number of processing cores to use for the classification operation. Defaults to 1.
-            code (int, optional): A numerical code to be used for the resulting boolean column. E.g. if code=16, then 
+            code (int, optional): A numerical code to be used for the resulting boolean column. E.g. if code=16, then
                                  the output column is Code16. Defaults to 16. Do not use 0.
             desc (str, optional): A brief description of the operation. Defaults to 'Classifying tracks toward point'.
 
         Returns:
             self: The Dataset instance.
         """
-        #get the files to process
-        pkl_groups = list(zip(*self._get_files_tracks_to_process(agents, tracks)))
-        #resample in parallel
-        utils.pool_caller(classify.classify_toward_point,
-                          (point, code),
-                          pkl_groups,
-                          desc,
-                          ncores)
-        #update meta
-        meta = 'Toward Point'
-        self.meta[f'Code{code}'] = meta
+        # get the files to process
+        pkl_groups = list(
+            zip(*self._get_files_tracks_to_process(agents, tracks))
+        )
+        # resample in parallel
+        utils.pool_caller(
+            classify.classify_toward_point,
+            (point, code),
+            pkl_groups,
+            desc,
+            ncores,
+        )
+        # update meta
+        meta = "Toward Point"
+        self.meta[f"Code{code}"] = meta
         return self
-    
-    def classify_speed(self, 
-                       speed, 
-                       higher=True, 
-                       lower=False, 
-                       agents=None,
-                       tracks=None, 
-                       ncores=1, 
-                       code=17,
-                       desc='Classifying tracks by speed threshold'):
+
+    def classify_speed(
+        self,
+        speed,
+        higher=True,
+        lower=False,
+        agents=None,
+        tracks=None,
+        ncores=1,
+        code=17,
+        desc="Classifying tracks by speed threshold",
+    ):
         """
         Classifies points on tracks based on a speed threshold, marking them according to whether their speeds are
         higher or lower than the specified threshold. This function is useful for identifying high-speed movements,
@@ -3547,7 +3801,7 @@ class Dataset:
                                     specified agents or all tracks if no agents are specified.
             ncores (int, optional): The number of processing cores to use for the classification operation. Defaults
                                     to 1.
-            code (int, optional): A numerical code to be used for the resulting boolean column. E.g. if code=17, then 
+            code (int, optional): A numerical code to be used for the resulting boolean column. E.g. if code=17, then
                                  the output column is Code17. Defaults to 17. Do not use 0.
             desc (str, optional): A brief description of the operation. Defaults to 'Classifying tracks by speed threshold',
                                 which can be customized for more specific descriptions or contexts of the classification.
@@ -3555,33 +3809,41 @@ class Dataset:
         Returns:
             self: The Dataset instance.
         """
-        #check for bounds
+        # check for bounds
         if lower:
             higher = False
         elif higher:
             lower = False
         else:
-            raise Exception('Must pass higher=True or lower=True, but not both')
-        #get the files to process
-        pkl_groups = list(zip(*self._get_files_tracks_to_process(agents, tracks)))
-        #process in parallel
-        utils.pool_caller(classify.classify_speed,
-                          (speed, higher, code),
-                          pkl_groups,
-                          desc,
-                          ncores)
-        #update meta
+            raise Exception(
+                "Must pass higher=True or lower=True, but not both"
+            )
+        # get the files to process
+        pkl_groups = list(
+            zip(*self._get_files_tracks_to_process(agents, tracks))
+        )
+        # process in parallel
+        utils.pool_caller(
+            classify.classify_speed,
+            (speed, higher, code),
+            pkl_groups,
+            desc,
+            ncores,
+        )
+        # update meta
         meta = f'Speed {">=" if higher else "<="} {speed}'
-        self.meta[f'Code{code}'] = meta
+        self.meta[f"Code{code}"] = meta
         return self
-    
-    def classify_turns(self, 
-                       rate, 
-                       agents=None,
-                       tracks=None, 
-                       ncores=1, 
-                       code=18,
-                       desc='Classifying turning tracks'):
+
+    def classify_turns(
+        self,
+        rate,
+        agents=None,
+        tracks=None,
+        ncores=1,
+        code=18,
+        desc="Classifying turning tracks",
+    ):
         """
         Classifies points on tracks based on their turning rate, identifying parts of tracks that exhibit turning behavior above
         a specified threshold. This can be particularly useful for understanding navigational patterns,
@@ -3600,36 +3862,38 @@ class Dataset:
                                     for the focused analysis of certain tracks. If None, the operation applies to tracks
                                     related to the specified agents or all tracks if no agents are specified.
             ncores (int, optional): The number of processing cores to use for the classification operation. Defaults to 1.
-            code (int, optional): A numerical code to be used for the resulting boolean column. E.g. if code=18, then 
+            code (int, optional): A numerical code to be used for the resulting boolean column. E.g. if code=18, then
                                  the output column is Code18. Defaults to 18. Do not use 0.
             desc (str, optional): A brief description of the operation. Defaults to 'Classifying turning tracks'.
 
         Returns:
             self: The Dataset instance.
         """
-        #get the files to process
-        pkl_groups = list(zip(*self._get_files_tracks_to_process(agents, tracks)))
-        #process in parallel
-        utils.pool_caller(classify.classify_turns,
-                          (rate, code),
-                          pkl_groups,
-                          desc,
-                          ncores)
-        #update meta
+        # get the files to process
+        pkl_groups = list(
+            zip(*self._get_files_tracks_to_process(agents, tracks))
+        )
+        # process in parallel
+        utils.pool_caller(
+            classify.classify_turns, (rate, code), pkl_groups, desc, ncores
+        )
+        # update meta
         meta = f"Turning rate >= {rate} deg/sec"
-        self.meta[f'Code{code}'] = meta
-        return self 
-    
-    def classify_speed_in_polygon(self, 
-                                  speed, 
-                                  polygon,
-                                  higher=True, 
-                                  lower=False, 
-                                  agents=None,
-                                  tracks=None, 
-                                  ncores=1, 
-                                  code=19,
-                                  desc='Classifying tracks by speed threshold in polygon') -> "Dataset":
+        self.meta[f"Code{code}"] = meta
+        return self
+
+    def classify_speed_in_polygon(
+        self,
+        speed,
+        polygon,
+        higher=True,
+        lower=False,
+        agents=None,
+        tracks=None,
+        ncores=1,
+        code=19,
+        desc="Classifying tracks by speed threshold in polygon",
+    ) -> "Dataset":
         """
         This is simply a combination of Dataset.classify_in_polygon and Dataset.classify_speed.
         This classifies points on tracks if they meet or don't meet a speed threshold inside of a given polygon.
@@ -3648,7 +3912,7 @@ class Dataset:
                                     specified agents or all tracks if no agents are specified.
             ncores (int, optional): The number of processing cores to use for the classification operation. Defaults
                                     to 1.
-            code (int, optional): A numerical code to be used for the resulting boolean column. E.g. if code=19, then 
+            code (int, optional): A numerical code to be used for the resulting boolean column. E.g. if code=19, then
                                  the output column is Code19. Defaults to 19. Do not use 0.
             desc (str, optional): A brief description of the operation. Defaults to 'Classifying tracks by speed threshold in polygon',
                                 which can be customized for more specific descriptions or contexts of the classification.
@@ -3656,35 +3920,41 @@ class Dataset:
         Returns:
             Dataset: The Dataset instance.
         """
-        #get polygon
+        # get polygon
         polygon, edges = utils.format_polygon(polygon)
-        #get the files to process
-        pkl_groups = list(zip(*self._get_files_tracks_to_process(agents, tracks)))
-        #process in parallel
-        utils.pool_caller(classify.classify_speed_in_polygon,
-                          (speed, polygon, edges, higher, code),
-                          pkl_groups,
-                          desc,
-                          ncores) 
-        #update meta
+        # get the files to process
+        pkl_groups = list(
+            zip(*self._get_files_tracks_to_process(agents, tracks))
+        )
+        # process in parallel
+        utils.pool_caller(
+            classify.classify_speed_in_polygon,
+            (speed, polygon, edges, higher, code),
+            pkl_groups,
+            desc,
+            ncores,
+        )
+        # update meta
         meta = f'Speed {">=" if higher else "<="} {speed} inside Polygon'
-        self.meta[f'Code{code}'] = meta
-        return self   
-    
-    def classify_trip(self, 
-                      poly1, 
-                      poly2,  
-                      agents=None,
-                      tracks=None, 
-                      ncores=1, 
-                      code=20,
-                      desc='Classifying tracks by trip'):
+        self.meta[f"Code{code}"] = meta
+        return self
+
+    def classify_trip(
+        self,
+        poly1,
+        poly2,
+        agents=None,
+        tracks=None,
+        ncores=1,
+        code=20,
+        desc="Classifying tracks by trip",
+    ):
         """
         Classifies tracks if they do a trip between two polygons (either direction).
 
         The track must start/end in poly1/poly2. Only the first and last points on the track are used for
         this classification.
-         
+
         If a track meets this condition, a boolean Code column will be added with True for every row in the track data.
 
         poly1 and poly2 must be shapely Polygons or Nx2 numpy arrays representing the outline of a polygon.
@@ -3699,46 +3969,52 @@ class Dataset:
                                     to tracks related to the specified agents or all tracks if no agents are specified.
             ncores (int, optional): The number of processing cores to use for the classification operation. Defaults
                                     to 1.
-            code (int, optional): A numerical code to be used for the resulting boolean column. E.g. if code=20, then 
+            code (int, optional): A numerical code to be used for the resulting boolean column. E.g. if code=20, then
                                  the output column is Code20. Defaults to 20. Do not use 0.
             desc (str, optional): A brief description of the operation. Defaults to 'Classifying tracks by trip'.
 
         Returns:
             self: The Dataset instance.
         """
-        #get polygons
+        # get polygons
         poly1, edges1 = utils.format_polygon(poly1)
         poly2, edges2 = utils.format_polygon(poly2)
-        #get the files to process
-        pkl_groups = list(zip(*self._get_files_tracks_to_process(agents, tracks)))
-        #process in parallel
-        utils.pool_caller(classify.classify_trip,
-                          (poly1, edges1, poly2, edges2, code),
-                          pkl_groups,
-                          desc,
-                          ncores)
-        #update meta
-        meta = 'Trip between 2 polygons'
-        self.meta[f'Code{code}'] = meta
-        return self 
-    
-    def classify_touching(self, 
-                          geom, 
-                          agents=None,
-                          tracks=None, 
-                          ncores=1, 
-                          code=21,
-                          desc='Classifying tracks touching object'):
+        # get the files to process
+        pkl_groups = list(
+            zip(*self._get_files_tracks_to_process(agents, tracks))
+        )
+        # process in parallel
+        utils.pool_caller(
+            classify.classify_trip,
+            (poly1, edges1, poly2, edges2, code),
+            pkl_groups,
+            desc,
+            ncores,
+        )
+        # update meta
+        meta = "Trip between 2 polygons"
+        self.meta[f"Code{code}"] = meta
+        return self
+
+    def classify_touching(
+        self,
+        geom,
+        agents=None,
+        tracks=None,
+        ncores=1,
+        code=21,
+        desc="Classifying tracks touching object",
+    ):
         """
-        Classifies tracks based on whether they touch or intersect a specified geometric object. 
-        
+        Classifies tracks based on whether they touch or intersect a specified geometric object.
+
         The geom kwarg must be a shapely LineString, MultiLineString, Polygon, or MultiPolygon.
 
         If a given track touches this object, the resulting boolean Code column will be True for
         every row in the track data.
-        
-        This function is useful for identifying movements that come into contact with geographic 
-        features or defined areas, supporting analyses related to boundary crossings, 
+
+        This function is useful for identifying movements that come into contact with geographic
+        features or defined areas, supporting analyses related to boundary crossings,
         interactions with areas of interest, or proximity to specific objects.
 
         Args:
@@ -3749,42 +4025,43 @@ class Dataset:
                                     This allows for selective analysis of certain tracks. If None, the operation applies
                                     to tracks related to the specified agents or all tracks if no agents are specified.
             ncores (int, optional): The number of processing cores to use for the classification operation. Defaults to 1.
-            code (int, optional): A numerical code to be used for the resulting boolean column. E.g. if code=21, then 
+            code (int, optional): A numerical code to be used for the resulting boolean column. E.g. if code=21, then
                                  the output column is Code21. Defaults to 21. Do not use 0.
             desc (str, optional): A brief description of the operation. Defaults to 'Classifying tracks touching object'.
 
         Returns:
             self: The Dataset instance.
         """
-        msg = 'geom must be shapely LineString, MultiLineString, Polygon, or MultiPolygon'
-        assert isinstance(geom, (LineString, 
-                                 MultiLineString, 
-                                 Polygon, 
-                                 MultiPolygon)), msg
-        #get the files to process
-        pkl_groups = list(zip(*self._get_files_tracks_to_process(agents, tracks)))
-        #process in parallel
-        utils.pool_caller(classify.classify_touching,
-                          (geom, code),
-                          pkl_groups,
-                          desc,
-                          ncores)
-        #update meta
-        meta = 'Touching object'
-        self.meta[f'Code{code}'] = meta
-        return self 
+        msg = "geom must be shapely LineString, MultiLineString, Polygon, or MultiPolygon"
+        assert isinstance(
+            geom, (LineString, MultiLineString, Polygon, MultiPolygon)
+        ), msg
+        # get the files to process
+        pkl_groups = list(
+            zip(*self._get_files_tracks_to_process(agents, tracks))
+        )
+        # process in parallel
+        utils.pool_caller(
+            classify.classify_touching, (geom, code), pkl_groups, desc, ncores
+        )
+        # update meta
+        meta = "Touching object"
+        self.meta[f"Code{code}"] = meta
+        return self
 
-    def classify_stops(self, 
-                       stop_threshold=0.15, 
-                       min_stop_duration=1800, 
-                       agents=None,
-                       tracks=None, 
-                       ncores=1, 
-                       code=22,
-                       desc='Classifying stopped tracks'):
+    def classify_stops(
+        self,
+        stop_threshold=0.15,
+        min_stop_duration=1800,
+        agents=None,
+        tracks=None,
+        ncores=1,
+        code=22,
+        desc="Classifying stopped tracks",
+    ):
         """
-        Classifies points along tracks where the agents have stopped, based on a specified speed threshold and minimum stop duration. 
-        
+        Classifies points along tracks where the agents have stopped, based on a specified speed threshold and minimum stop duration.
+
         If points along tracks meet the stopping thresholds, the resulting boolean Code column will be True, otherrwise False.
 
         The stop_threshold is in the same units as the Dataset CRS, i.e. degrees for geographic or meters for UTM, etc.
@@ -3801,45 +4078,51 @@ class Dataset:
                                     of certain tracks. If None, the operation applies to tracks related to the specified agents
                                     or all tracks if no agents are specified.
             ncores (int, optional): The number of processing cores to use for the classification operation. Defaults to 1.
-            code (int, optional): A numerical code to be used for the resulting boolean column. E.g. if code=22, then 
+            code (int, optional): A numerical code to be used for the resulting boolean column. E.g. if code=22, then
                                  the output column is Code22. Defaults to 22. Do not use 0.
             desc (str, optional): A brief description of the operation. Defaults to 'Classifying stopped tracks'.
 
         Returns:
             self: The Dataset instance.
         """
-            #get the files to process
-        pkl_groups = list(zip(*self._get_files_tracks_to_process(agents, tracks)))
-        #process in parallel
-        utils.pool_caller(classify.classify_stops,
-                          (stop_threshold, min_stop_duration, code),
-                          pkl_groups,
-                          desc,
-                          ncores)
-        #update meta
-        meta = f'Stopped: Speed <= {stop_threshold} and Duration >= {min_stop_duration}'
-        self.meta[f'Code{code}'] = meta
-        return self 
+        # get the files to process
+        pkl_groups = list(
+            zip(*self._get_files_tracks_to_process(agents, tracks))
+        )
+        # process in parallel
+        utils.pool_caller(
+            classify.classify_stops,
+            (stop_threshold, min_stop_duration, code),
+            pkl_groups,
+            desc,
+            ncores,
+        )
+        # update meta
+        meta = f"Stopped: Speed <= {stop_threshold} and Duration >= {min_stop_duration}"
+        self.meta[f"Code{code}"] = meta
+        return self
 
-    def classify_custom(self, 
-                        values, 
-                        ncores=1, 
-                        code=23,
-                        desc='Classifying tracks with custom code',
-                        meta='Custom classifier'):
+    def classify_custom(
+        self,
+        values,
+        ncores=1,
+        code=23,
+        desc="Classifying tracks with custom code",
+        meta="Custom classifier",
+    ):
         """
         Applies a custom classification to tracks based on an input pandas DataFrame.
 
         This DataFrame must have an index consisting of Track IDs, and a "Value" column consisting
         of True/False values to classify the tracks.
-        
-        This offers flexibility to implement user-defined classification logic into the trackio framework, 
-        supporting a wide range of analytical needs from behavior categorization to environmental interaction analysis. 
+
+        This offers flexibility to implement user-defined classification logic into the trackio framework,
+        supporting a wide range of analytical needs from behavior categorization to environmental interaction analysis.
 
         Args:
             values (pd.DataFrame): values must be a pd.DataFrame with Track IDs as index, and a "Value" column consisting of booleans.
             ncores (int, optional): The number of processing cores to use for the classification operation. Defaults to 1.
-            code (int, optional): A numerical code to be used for the resulting boolean column. E.g. if code=23, then 
+            code (int, optional): A numerical code to be used for the resulting boolean column. E.g. if code=23, then
                                  the output column is Code23. Defaults to 23. Do not use 0.
             desc (str, optional): A brief description of the operation. Defaults to 'Classifying tracks with custom code'.
             meta (str, optional): A description related to the custom classifier being applied. This gets added
@@ -3848,98 +4131,95 @@ class Dataset:
         Returns:
             self: The Dataset instance.
         """
-        #make sure it contains the column and is boolean
+        # make sure it contains the column and is boolean
         msg = 'values must be a pd.DataFrame with Track IDs as index, and a "Value" column consisting of booleans'
-        assert 'Value' in values.columns and values['Value'].dtype == bool, msg
-        #get the files to process
-        pkl_groups = list(zip(*self._get_files_tracks_to_process(None, values.index)))
-        #process in parallel
-        utils.pool_caller(classify.classify_custom,
-                          (values, code),
-                          pkl_groups,
-                          desc,
-                          ncores)
-        #update meta
-        self.meta[f'Code{code}'] = meta
+        assert "Value" in values.columns and values["Value"].dtype == bool, msg
+        # get the files to process
+        pkl_groups = list(
+            zip(*self._get_files_tracks_to_process(None, values.index))
+        )
+        # process in parallel
+        utils.pool_caller(
+            classify.classify_custom, (values, code), pkl_groups, desc, ncores
+        )
+        # update meta
+        self.meta[f"Code{code}"] = meta
         return self
-       
+
+
 ################################################################################
 
+
 def _meta_to_agents(meta, crs):
-    #make dataframe from meta dict
-    df = pd.DataFrame(meta).T.set_index('Agent ID')
-    #drop track meta dicts
+    # make dataframe from meta dict
+    df = pd.DataFrame(meta).T.set_index("Agent ID")
+    # drop track meta dicts
     df.drop(columns=["Tracks"], inplace=True)
-    #make bounding box geometry
-    _geometry = df[['Xmin',
-                   'Ymin',
-                   'Xmax',
-                   'Ymax']].apply(lambda b: box(b['Xmin'], 
-                                               b['Ymin'], 
-                                               b['Xmax'], 
-                                               b['Ymax']), axis=1)
-    #convert to geodataframe
+    # make bounding box geometry
+    _geometry = df[["Xmin", "Ymin", "Xmax", "Ymax"]].apply(
+        lambda b: box(b["Xmin"], b["Ymin"], b["Xmax"], b["Ymax"]), axis=1
+    )
+    # convert to geodataframe
     df = gp.GeoDataFrame(df, geometry=_geometry, crs=crs)
     return df
 
+
 def _meta_to_tracks(meta, crs):
-    #initialize dataframe rows/indices
+    # initialize dataframe rows/indices
     rows = []
     # ids = []
-    #loop over meta dict, create entries for each track
+    # loop over meta dict, create entries for each track
     for vid, vmeta in meta.items():
-        #get the track ids
+        # get the track ids
         # _ids = [f"{vid}_{tid}" for tid in vmeta["Tracks"].keys()]
-        #get the combined track meta rows
-        _vmeta = {k:v for k,v in vmeta.items() if k != 'Tracks'}
+        # get the combined track meta rows
+        _vmeta = {k: v for k, v in vmeta.items() if k != "Tracks"}
         tmeta = [
             {**_vmeta, **vmeta["Tracks"][tid]}
             for tid in vmeta["Tracks"].keys()
         ]
         # ids.extend(_ids)
         rows.extend(tmeta)
-    #create dataframe from rows and indices
+    # create dataframe from rows and indices
     df = pd.DataFrame(rows)
     # df.index = ids
-    df.set_index('Track ID', inplace=True)
-    #create bounding box geometry
-    _geometry = df[['Xmin',
-                   'Ymin',
-                   'Xmax',
-                   'Ymax']].apply(lambda b: box(b['Xmin'], 
-                                               b['Ymin'], 
-                                               b['Xmax'], 
-                                               b['Ymax']), axis=1)
-    #drop pointless column
+    df.set_index("Track ID", inplace=True)
+    # create bounding box geometry
+    _geometry = df[["Xmin", "Ymin", "Xmax", "Ymax"]].apply(
+        lambda b: box(b["Xmin"], b["Ymin"], b["Xmax"], b["Ymax"]), axis=1
+    )
+    # drop pointless column
     df.drop(columns=["ntracks"], inplace=True)
-    #convert to geodataframe
+    # convert to geodataframe
     df = gp.GeoDataFrame(df, geometry=_geometry, crs=crs)
     return df
 
+
 def _refresh_meta(agents_only, file):
-    #make a new meta dict and track_meta dict
+    # make a new meta dict and track_meta dict
     meta = {}
     track_meta = {}
-    #read the vessel
+    # read the vessel
     v = utils.read_pkl(file)
-    #loop over tracks, populate track_meta
+    # loop over tracks, populate track_meta
     tids = v.tracks.keys()
     for tid in tids:
         track_meta[tid] = gen_track_meta(v.tracks[tid])
-        track_meta[tid]['Track ID'] = f"{v.meta['Agent ID']}_{tid}"
-    #reset vessel.track_meta
+        track_meta[tid]["Track ID"] = f"{v.meta['Agent ID']}_{tid}"
+    # reset vessel.track_meta
     v.track_meta = track_meta
-    #reset vessel.vessel_meta
+    # reset vessel.vessel_meta
     v.agent_meta = gen_agent_meta(v)
-    v.agent_meta['File'] = file
-    #update output meta dict
-    meta[v.agent_meta['Agent ID']] = v.agent_meta
-    meta[v.agent_meta['Agent ID']]['Tracks'] = track_meta
-    #if tracks not split, pings exist in pickle chunks - don't overwrite
+    v.agent_meta["File"] = file
+    # update output meta dict
+    meta[v.agent_meta["Agent ID"]] = v.agent_meta
+    meta[v.agent_meta["Agent ID"]]["Tracks"] = track_meta
+    # if tracks not split, pings exist in pickle chunks - don't overwrite
     if not agents_only:
         utils.save_pkl(file, v)
     meta_cols = list(v.meta.keys())
     data_cols = v.data.columns.tolist()
     return meta, meta_cols, data_cols
+
 
 ################################################################################

--- a/trackio/Dataset.py
+++ b/trackio/Dataset.py
@@ -269,6 +269,7 @@ class Dataset:
                      continued=False,
                      prefix='agent',
                      ncores=1,
+                     sep=',',
                      desc='Grouping points'):
         """
         Groups all points in Dataset based on groupby column(s) to isolate
@@ -291,6 +292,7 @@ class Dataset:
             continued (bool): Flag to indicate continuation of previous processing in Dataset.data_path. Defaults to False.
             prefix (str): Prefix for output files. Defaults to 'agent'.
             ncores (int): Number of cores to use for processing. Defaults to 1.
+            sep (str, optional): The separator of the csv file. Defaults to ','.
             desc (str): Description of the operation. Defaults to 'Grouping points'.
 
         Returns:
@@ -319,7 +321,8 @@ class Dataset:
                     meta_cols,
                     data_cols,
                     data_mappers,
-                    prefix)
+                    prefix,
+                    sep)
         #if any raw files
         if len(raw_files) > 0:
             #process in parallel

--- a/trackio/__init__.py
+++ b/trackio/__init__.py
@@ -1,37 +1,29 @@
 ################################################################################
 
 from .Dataset import Dataset
-from .Agent import Agent
-from .io import rasterize, create_blank_raster
-from .utils import read_pkl as read_agent
-from .utils import save_pkl as write_agent
-from .process import clip_to_polygon, clip_to_box
-from .maps import _mappers as mappers
-from .maps import make_col_mapper, make_raw_data_mapper
 
 ################################################################################
 
-def read(raw_files=None, 
-         data_files=None,
-         data_path='./data'):
+
+def read(raw_files=None, data_files=None, data_path="./data"):
     """
     Instantiates a trackio.Dataset object from either raw or processed data files.
 
     Args:
         raw_files (list, optional): List of raw file paths.
         data_files (list, optional): List of processed data file paths (*.points or *.tracks).
-                                    If None, it detect any files in the data_path. 
+                                    If None, it detect any files in the data_path.
         data_path (str): Path for data files. Defaults to './data'.
 
     Returns:
         Dataset: A trackio.Dataset object initialized with the given parameters.
     """
-    return Dataset(raw_files=raw_files,
-                   data_files=data_files,
-                   data_path=data_path)
-    
-def from_df(raw_df,
-            data_path='.'):
+    return Dataset(
+        raw_files=raw_files, data_files=data_files, data_path=data_path
+    )
+
+
+def from_df(raw_df, data_path="."):
     """
     Instantiates a trackio.Dataset object from a pandas DataFrame of raw point data.
 
@@ -42,11 +34,10 @@ def from_df(raw_df,
     Returns:
         Dataset: A trackio.Dataset object initialized with the given parameters.
     """
-    return Dataset(raw_df=raw_df,
-                   data_path=data_path)
-     
-def from_gdf(raw_gdf,
-             data_path='.'):
+    return Dataset(raw_df=raw_df, data_path=data_path)
+
+
+def from_gdf(raw_gdf, data_path="."):
     """
     Instantiates a trackio.Dataset object from a geopandas GeoDataFrame of raw data.
 
@@ -60,5 +51,4 @@ def from_gdf(raw_gdf,
     Returns:
         Dataset: A trackio.Dataset object initialized with the given parameters.
     """
-    return Dataset(raw_gdf=raw_gdf,
-                   data_path=data_path)
+    return Dataset(raw_gdf=raw_gdf, data_path=data_path)

--- a/trackio/__init__.py
+++ b/trackio/__init__.py
@@ -1,6 +1,13 @@
 ################################################################################
 
+from .Agent import Agent
 from .Dataset import Dataset
+from .io import create_blank_raster, rasterize
+from .maps import _mappers as mappers
+from .maps import make_col_mapper, make_raw_data_mapper
+from .process import clip_to_box, clip_to_polygon
+from .utils import read_pkl as read_agent
+from .utils import save_pkl as write_agent
 
 ################################################################################
 

--- a/trackio/ais.py
+++ b/trackio/ais.py
@@ -107,7 +107,7 @@
 #                 'Length':length,
 #                 'Width':width}
 #         return out
-        
+
 # # def vesselfinder_meta(mmsi=None, imo=None, name=None):
 # #     #set urls
 # #     search_url = "https://www.vesselfinder.com/vessels?name="
@@ -154,7 +154,7 @@
 # #         psoup = bs(page.text, features="html.parser")
 # #         #try to find table
 # #         try:
-# #             table = psoup.find('h2', text='Vessel Particulars').parent.find_all('tr') 
+# #             table = psoup.find('h2', text='Vessel Particulars').parent.find_all('tr')
 # #         except AttributeError:
 # #             return empty_info()
 # #         #format table
@@ -198,7 +198,7 @@
 # #                'Length':length,
 # #                'Width':width}
 # #         return out
-            
+
 # # def marinetraffic_meta(mmsi=None, imo=None, name=None):
 # #     #set urls
 # #     search_url = "https://www.marinetraffic.com/en/global_search/search?term="
@@ -296,8 +296,8 @@
 # #         #first check if mmsi is available for search
 # #         if isinstance(row['mmsi'], str) or isinstance(row['mmsi'], int):
 # #             #loop over fetchers
-# #             for fetcher in (marinetraffic_meta, 
-# #                             vesselfinder_meta, 
+# #             for fetcher in (marinetraffic_meta,
+# #                             vesselfinder_meta,
 # #                             myshiptracking_meta):
 # #                 res = fetcher(mmsi=row['mmsi'])
 # #                 #if empty, pass so it goes to next fetcher
@@ -314,8 +314,8 @@
 # #         #second check for name to search
 # #         if isinstance(row['name'], str):
 # #             #loop over fetchers
-# #             for fetcher in (marinetraffic_meta, 
-# #                             vesselfinder_meta, 
+# #             for fetcher in (marinetraffic_meta,
+# #                             vesselfinder_meta,
 # #                             myshiptracking_meta):
 # #                 res = fetcher(name=row['name'])
 # #                 #if empty, pass so it goes to next fetcher
@@ -332,8 +332,8 @@
 # #         #third check if imo to search
 # #         if isinstance(row['imo'], str) or isinstance(row['imo'], int):
 # #             #loop over fetchers
-# #             for fetcher in (marinetraffic_meta, 
-# #                             vesselfinder_meta, 
+# #             for fetcher in (marinetraffic_meta,
+# #                             vesselfinder_meta,
 # #                             myshiptracking_meta):
 # #                 res = fetcher(imo=row['imo'])
 # #                 #if empty, pass so it goes to next fetcher
@@ -358,7 +358,7 @@
 # #     out['Width_original'] = search['width'].values
 # #     out.index = search.index
 # #     return out
-        
+
 # ################################################################################
 
 
@@ -376,7 +376,7 @@
 # # mask6 = vdb['Width'] <= 0 #abnormal width
 
 # # #get the chunk of the vessel database, only need 6 columns for this
-# # keep_cols = ['Name','MMSI','IMO', 
+# # keep_cols = ['Name','MMSI','IMO',
 # #              'Type', 'Length', 'Width']
 # # search = vdb[(mask1|mask2|mask3|mask4|mask5|mask6)][keep_cols]
 

--- a/trackio/classify.py
+++ b/trackio/classify.py
@@ -1,105 +1,113 @@
 ################################################################################
 
-from .utils import save_pkl, collect_agent_pkls, first_nonzero
-
+import numpy as np
+import pandas as pd
+from inpoly import inpoly2
+from more_itertools import consecutive_groups
 from shapely import geometry
 from shapely.geometry import Point
-from inpoly import inpoly2
-import numpy as np
-from more_itertools import consecutive_groups
-import pandas as pd
+
+from .utils import collect_agent_pkls, first_nonzero, save_pkl
 
 ################################################################################
-        
-def classify_in_polygon(polygon, 
-                        edges, 
-                        code, 
-                        args):
-    #split args
+
+
+def classify_in_polygon(polygon, edges, code, args):
+    # split args
     pkl_files, tracks = args
-    #read split agent file
+    # read split agent file
     agent = collect_agent_pkls(pkl_files)
-    #reduce to tracks of interest
+    # reduce to tracks of interest
     if len(tracks) > 0:
-        tids = [tid for tid in agent.tracks.keys() 
-                if f'{agent.agent_meta["Agent ID"]}_{tid}' in tracks]
+        tids = [
+            tid
+            for tid in agent.tracks.keys()
+            if f'{agent.agent_meta["Agent ID"]}_{tid}' in tracks
+        ]
     else:
         tids = agent.tracks.keys()
-    #loop over each track
+    # loop over each track
     for tid in tids:
         track = agent.tracks[tid]
-        #classify points
-        x = track['X'].values
-        y = track['Y'].values
-        result = np.logical_or(*inpoly2(np.column_stack((x, y)), 
-                                        polygon, 
-                                        edges, ftol=1e-8))
-        track.loc[:,f'Code{code}'] = result
-    #save the file
+        # classify points
+        x = track["X"].values
+        y = track["Y"].values
+        result = np.logical_or(
+            *inpoly2(np.column_stack((x, y)), polygon, edges, ftol=1e-8)
+        )
+        track.loc[:, f"Code{code}"] = result
+    # save the file
     save_pkl(pkl_files[0], agent)
 
-def classify_in_polygons(polys, 
-                         to_codes,
-                         name,
-                         args):
-    #split args
+
+def classify_in_polygons(polys, to_codes, name, args):
+    # split args
     pkl_files, tracks = args
-    #read split agent file
+    # read split agent file
     agent = collect_agent_pkls(pkl_files)
-    #reduce to tracks of interest
+    # reduce to tracks of interest
     if len(tracks) > 0:
-        tids = [tid for tid in agent.tracks.keys() 
-                if f'{agent.agent_meta["Agent ID"]}_{tid}' in tracks]
+        tids = [
+            tid
+            for tid in agent.tracks.keys()
+            if f'{agent.agent_meta["Agent ID"]}_{tid}' in tracks
+        ]
     else:
         tids = agent.tracks.keys()
-    #loop over each track
+    # loop over each track
     for tid in tids:
         track = agent.tracks[tid]
-        #classify points
-        x = track['X'].values
-        y = track['Y'].values
-        #loop over polys
+        # classify points
+        x = track["X"].values
+        y = track["Y"].values
+        # loop over polys
         codes = {}
         route = {}
         for i in range(len(polys)):
-            polycode = polys.iloc[i]['Code']
-            poly, edges = polys.iloc[i]['polys']
-            result = np.logical_or(*inpoly2(np.column_stack((x, y)), 
-                                            poly, 
-                                            edges, ftol=1e-8))
-            codes[f'Code{polycode}'] = result
-            route[f'Code{polycode}'] = result*polycode
-        #reduce route to single array
+            polycode = polys.iloc[i]["Code"]
+            poly, edges = polys.iloc[i]["polys"]
+            result = np.logical_or(
+                *inpoly2(np.column_stack((x, y)), poly, edges, ftol=1e-8)
+            )
+            codes[f"Code{polycode}"] = result
+            route[f"Code{polycode}"] = result * polycode
+        # reduce route to single array
         route = pd.DataFrame(route)
         route = route.apply(first_nonzero, axis=1).values
-        track.loc[:,name] = route        
-        #add codes
+        track.loc[:, name] = route
+        # add codes
         if to_codes:
-            for key,val in codes.items():
-                track.loc[:,key] = val
-    #save the file
+            for key, val in codes.items():
+                track.loc[:, key] = val
+    # save the file
     save_pkl(pkl_files[0], agent)
 
-def classify_toward_point(point: Point, 
-                        code: int, 
-                        args: tuple):
-    #split args
+
+def classify_toward_point(point: Point, code: int, args: tuple):
+    # split args
     pkl_files, tracks = args
 
-    #read split agent file
+    # read split agent file
     agent = collect_agent_pkls(pkl_files)
-    #reduce to tracks of interest
+    # reduce to tracks of interest
     if len(tracks) > 0:
-        tids = [tid for tid in agent.tracks.keys() 
-                if f'{agent.agent_meta["Agent ID"]}_{tid}' in tracks]
+        tids = [
+            tid
+            for tid in agent.tracks.keys()
+            if f'{agent.agent_meta["Agent ID"]}_{tid}' in tracks
+        ]
     else:
         tids = agent.tracks.keys()
-    #loop over each track
+    # loop over each track
 
     for tid in tids:
         track = agent.tracks[tid]
-        start_coordinate = geometry.Point(track["X"].iloc[0], track["Y"].iloc[0])
-        stop_coordinate = geometry.Point(track["X"].iloc[-1], track["Y"].iloc[-1])
+        start_coordinate = geometry.Point(
+            track["X"].iloc[0], track["Y"].iloc[0]
+        )
+        stop_coordinate = geometry.Point(
+            track["X"].iloc[-1], track["Y"].iloc[-1]
+        )
         distance_start = start_coordinate.distance(point)
         distance_stop = stop_coordinate.distance(point)
         if distance_start > distance_stop:
@@ -107,72 +115,78 @@ def classify_toward_point(point: Point,
         else:
             result = False
 
-        track.loc[:,f'Code{code}'] = result
-    
-    #save the file
+        track.loc[:, f"Code{code}"] = result
+
+    # save the file
     save_pkl(pkl_files[0], agent)
 
-def classify_speed(speed, 
-                   higher, 
-                   code, 
-                   args):
+
+def classify_speed(speed, higher, code, args):
     if higher:
-        method = 'higher'
+        method = "higher"
     else:
-        method = 'lower'
-    #split args
+        method = "lower"
+    # split args
     pkl_files, tracks = args
-    #read split agent file
+    # read split agent file
     agent = collect_agent_pkls(pkl_files)
-    #reduce to tracks of interest
+    # reduce to tracks of interest
     if len(tracks) > 0:
-        tids = [tid for tid in agent.tracks.keys() 
-                if f'{agent.agent_meta["Agent ID"]}_{tid}' in tracks]
+        tids = [
+            tid
+            for tid in agent.tracks.keys()
+            if f'{agent.agent_meta["Agent ID"]}_{tid}' in tracks
+        ]
     else:
         tids = agent.tracks.keys()
-    #loop over each track
+    # loop over each track
     for tid in tids:
         track = agent.tracks[tid]
-        #classify points
-        if method == 'higher':
-            result = track['Speed'].values >= speed
+        # classify points
+        if method == "higher":
+            result = track["Speed"].values >= speed
         else:
-            result = track['Speed'].values <= speed
-        track.loc[:,f'Code{code}'] = result
-    #save the file
+            result = track["Speed"].values <= speed
+        track.loc[:, f"Code{code}"] = result
+    # save the file
     save_pkl(pkl_files[0], agent)
     return
 
-def classify_turns(rate, 
-                   code, 
-                   args):
-    #split args
+
+def classify_turns(rate, code, args):
+    # split args
     pkl_files, tracks = args
-    #read split agent file
+    # read split agent file
     agent = collect_agent_pkls(pkl_files)
-    #reduce to tracks of interest
+    # reduce to tracks of interest
     if len(tracks) > 0:
-        tids = [tid for tid in agent.tracks.keys() 
-                if f'{agent.agent_meta["Agent ID"]}_{tid}' in tracks]
+        tids = [
+            tid
+            for tid in agent.tracks.keys()
+            if f'{agent.agent_meta["Agent ID"]}_{tid}' in tracks
+        ]
     else:
         tids = agent.tracks.keys()
-    #loop over each track
+    # loop over each track
     for tid in tids:
         track = agent.tracks[tid]
-        #classify points
-        result = np.abs(track['Turning Rate'].values) >= rate
-        track.loc[:,f'Code{code}'] = result
-    #save the file
+        # classify points
+        result = np.abs(track["Turning Rate"].values) >= rate
+        track.loc[:, f"Code{code}"] = result
+    # save the file
     save_pkl(pkl_files[0], agent)
     return
-    
-def _classify_speed_inpoly(x: np.ndarray[float], 
-                           y: np.ndarray[float], 
-                           speeds: np.ndarray[float], 
-                           poly: np.ndarray, 
-                           edges: tuple,
-                           speed: float, 
-                           higher: bool) -> np.ndarray[bool]:
+
+
+def _classify_speed_inpoly(
+    x: np.ndarray[float],
+    y: np.ndarray[float],
+    speeds: np.ndarray[float],
+    poly: np.ndarray,
+    edges: tuple,
+    speed: float,
+    higher: bool,
+) -> np.ndarray[bool]:
     """Classify if datapoints lie within a given polygon and its speed is higher or lower than a certain velocity.
 
     Args:
@@ -193,12 +207,15 @@ def _classify_speed_inpoly(x: np.ndarray[float],
     else:
         return np.logical_and(np.logical_or(*isin), (speeds <= speed))
 
-def classify_speed_in_polygon(speed: float, 
-                              poly: np.ndarray, 
-                              edges: tuple, 
-                              higher: bool, 
-                              code: int, 
-                              args: list):
+
+def classify_speed_in_polygon(
+    speed: float,
+    poly: np.ndarray,
+    edges: tuple,
+    higher: bool,
+    code: int,
+    args: list,
+):
     """Classify if datapoints lie within a given polygon and its speed is higher or lower than a certain velocity.
 
     Args:
@@ -209,191 +226,186 @@ def classify_speed_in_polygon(speed: float,
         code (int): The numer of the code column to which the classification bool will be written.
         args (list): Essentially the binary file names and track list if specified.
     """
-    #split args
+    # split args
     pkl_files, tracks = args
-    #read split agent file
+    # read split agent file
     agent = collect_agent_pkls(pkl_files)
-    #reduce to tracks of interest
+    # reduce to tracks of interest
     if len(tracks) > 0:
-        tids = [tid for tid in agent.tracks.keys() 
-                if f'{agent.agent_meta["Agent ID"]}_{tid}' in tracks]
+        tids = [
+            tid
+            for tid in agent.tracks.keys()
+            if f'{agent.agent_meta["Agent ID"]}_{tid}' in tracks
+        ]
     else:
         tids = agent.tracks.keys()
-    #loop over each track
+    # loop over each track
     for tid in tids:
         track = agent.tracks[tid]
-        #classify points
-        speeds = track['Speed'].values
-        x, y = track['X'].values, track['Y'].values
-        result = _classify_speed_inpoly(x,
-                                        y,
-                                        speeds,
-                                        poly,
-                                        edges,
-                                        speed,
-                                        higher)
-        track.loc[:,f'Code{code}'] = result
-    #save the file
-    save_pkl(pkl_files[0], agent)
-   
-def _classify_trip(x,
-                   y, 
-                   poly1, 
-                   edges1, 
-                   poly2, 
-                   edges2):      
-    #one way
-    startsin1 = np.logical_or(*inpoly2(np.column_stack((x[0], y[0])), 
-                                       poly1, 
-                                       edges1, ftol=1e-8))[0]
-    endsin2 = np.logical_or(*inpoly2(np.column_stack((x[-1], y[-1])), 
-                                     poly2, 
-                                     edges2, ftol=1e-8))[-1]
-    way1 = startsin1 and endsin2
-    #other way
-    startsin2 = np.logical_or(*inpoly2(np.column_stack((x[0], y[0])), 
-                                       poly2, 
-                                       edges2, ftol=1e-8))[0]
-    endsin1 = np.logical_or(*inpoly2(np.column_stack((x[-1], y[-1])), 
-                                     poly1, 
-                                     edges1, ftol=1e-8))[-1]
-    way2 = startsin2 and endsin1
-    #either
-    if way1 or way2:
-        return np.array([True]*len(x))
-    else:
-        return np.array([False]*len(x))
-  
-def classify_trip(poly1, 
-                  edges1,
-                  poly2, 
-                  edges2, 
-                  code, 
-                  args):
-    #split args
-    pkl_files, tracks = args
-    #read split agent file
-    agent = collect_agent_pkls(pkl_files)
-    #reduce to tracks of interest
-    if len(tracks) > 0:
-        tids = [tid for tid in agent.tracks.keys() 
-                if f'{agent.agent_meta["Agent ID"]}_{tid}' in tracks]
-    else:
-        tids = agent.tracks.keys()
-    #loop over each track
-    for tid in tids:
-        track = agent.tracks[tid]
-        x = track['X'].values
-        y = track['Y'].values
-        result = _classify_trip(x,
-                                y,
-                                poly1,
-                                edges1,
-                                poly2,
-                                edges2)
-        track.loc[:,f'Code{code}'] = result
-    #save the file
+        # classify points
+        speeds = track["Speed"].values
+        x, y = track["X"].values, track["Y"].values
+        result = _classify_speed_inpoly(
+            x, y, speeds, poly, edges, speed, higher
+        )
+        track.loc[:, f"Code{code}"] = result
+    # save the file
     save_pkl(pkl_files[0], agent)
 
-def _classify_touches(x, 
-                      y, 
-                      geom):
+
+def _classify_trip(x, y, poly1, edges1, poly2, edges2):
+    # one way
+    startsin1 = np.logical_or(
+        *inpoly2(np.column_stack((x[0], y[0])), poly1, edges1, ftol=1e-8)
+    )[0]
+    endsin2 = np.logical_or(
+        *inpoly2(np.column_stack((x[-1], y[-1])), poly2, edges2, ftol=1e-8)
+    )[-1]
+    way1 = startsin1 and endsin2
+    # other way
+    startsin2 = np.logical_or(
+        *inpoly2(np.column_stack((x[0], y[0])), poly2, edges2, ftol=1e-8)
+    )[0]
+    endsin1 = np.logical_or(
+        *inpoly2(np.column_stack((x[-1], y[-1])), poly1, edges1, ftol=1e-8)
+    )[-1]
+    way2 = startsin2 and endsin1
+    # either
+    if way1 or way2:
+        return np.array([True] * len(x))
+    else:
+        return np.array([False] * len(x))
+
+
+def classify_trip(poly1, edges1, poly2, edges2, code, args):
+    # split args
+    pkl_files, tracks = args
+    # read split agent file
+    agent = collect_agent_pkls(pkl_files)
+    # reduce to tracks of interest
+    if len(tracks) > 0:
+        tids = [
+            tid
+            for tid in agent.tracks.keys()
+            if f'{agent.agent_meta["Agent ID"]}_{tid}' in tracks
+        ]
+    else:
+        tids = agent.tracks.keys()
+    # loop over each track
+    for tid in tids:
+        track = agent.tracks[tid]
+        x = track["X"].values
+        y = track["Y"].values
+        result = _classify_trip(x, y, poly1, edges1, poly2, edges2)
+        track.loc[:, f"Code{code}"] = result
+    # save the file
+    save_pkl(pkl_files[0], agent)
+
+
+def _classify_touches(x, y, geom):
     if len(x) == 1:
-        return np.array([False]*len(x))
+        return np.array([False] * len(x))
     else:
         ls = geometry.LineString(zip(x, y))
     if geom.intersects(ls):
-        return np.array([True]*len(x))
+        return np.array([True] * len(x))
     else:
-        return np.array([False]*len(x))
+        return np.array([False] * len(x))
 
-def classify_touching(geom, 
-                      code, 
-                      args):
-    #split args
+
+def classify_touching(geom, code, args):
+    # split args
     pkl_files, tracks = args
-    #read split agent file
+    # read split agent file
     agent = collect_agent_pkls(pkl_files)
-    #reduce to tracks of interest
+    # reduce to tracks of interest
     if len(tracks) > 0:
-        tids = [tid for tid in agent.tracks.keys() 
-                if f'{agent.agent_meta["Agent ID"]}_{tid}' in tracks]
+        tids = [
+            tid
+            for tid in agent.tracks.keys()
+            if f'{agent.agent_meta["Agent ID"]}_{tid}' in tracks
+        ]
     else:
         tids = agent.tracks.keys()
-    #loop over each track
+    # loop over each track
     for tid in tids:
         track = agent.tracks[tid]
-        x = track['X'].values
-        y = track['Y'].values
-        result = _classify_touches(x,
-                                   y,
-                                   geom)
-        track.loc[:,f'Code{code}'] = result
-    #save the file
+        x = track["X"].values
+        y = track["Y"].values
+        result = _classify_touches(x, y, geom)
+        track.loc[:, f"Code{code}"] = result
+    # save the file
     save_pkl(pkl_files[0], agent)
 
-def _classify_stops(time, 
-                    speed, 
-                    stop_threshold, 
-                    min_stop_duration):
-    #find the stops
+
+def _classify_stops(time, speed, stop_threshold, min_stop_duration):
+    # find the stops
     stops = np.nonzero(speed <= stop_threshold)[0]
-    #group the stops
+    # group the stops
     stop_ids = [list(g) for g in consecutive_groups(stops)]
     stop_ids = [s for s in stop_ids if len(s) > 1]
-    #remove stops less than duration threshold
-    stop_ids = [s for s in stop_ids 
-                if (time[s[-1]] - time[s[0]]).total_seconds() >= min_stop_duration]
-    #flatten the list
+    # remove stops less than duration threshold
+    stop_ids = [
+        s
+        for s in stop_ids
+        if (time[s[-1]] - time[s[0]]).total_seconds() >= min_stop_duration
+    ]
+    # flatten the list
     stop_ids = [s for stop in stop_ids for s in stop]
-    #make the output array
-    out = np.array([False]*len(time))
+    # make the output array
+    out = np.array([False] * len(time))
     out[stop_ids] = True
     return out
 
-def classify_stops(stop_threshold, 
-                   min_stop_duration, 
-                   code, 
-                   args):
-    #split args
+
+def classify_stops(stop_threshold, min_stop_duration, code, args):
+    # split args
     pkl_files, tracks = args
-    #read split agent file
+    # read split agent file
     agent = collect_agent_pkls(pkl_files)
-    #reduce to tracks of interest
+    # reduce to tracks of interest
     if len(tracks) > 0:
-        tids = [tid for tid in agent.tracks.keys() 
-                if f'{agent.agent_meta["Agent ID"]}_{tid}' in tracks]
+        tids = [
+            tid
+            for tid in agent.tracks.keys()
+            if f'{agent.agent_meta["Agent ID"]}_{tid}' in tracks
+        ]
     else:
         tids = agent.tracks.keys()
-    #loop over each track
+    # loop over each track
     for tid in tids:
         track = agent.tracks[tid]
-        speed = track['Speed'].values
-        time = track['Time']
-        result = _classify_stops(time, speed, stop_threshold, min_stop_duration)
-        track.loc[:,f'Code{code}'] = result
-    #save the file
+        speed = track["Speed"].values
+        time = track["Time"]
+        result = _classify_stops(
+            time, speed, stop_threshold, min_stop_duration
+        )
+        track.loc[:, f"Code{code}"] = result
+    # save the file
     save_pkl(pkl_files[0], agent)
 
-def classify_custom(values, 
-                    code, 
-                    args):
-    #split args
+
+def classify_custom(values, code, args):
+    # split args
     pkl_files, tracks = args
-    #read split agent file
+    # read split agent file
     agent = collect_agent_pkls(pkl_files)
-    #reduce to tracks of interest
+    # reduce to tracks of interest
     if len(tracks) > 0:
-        tids = [tid for tid in agent.tracks.keys() 
-                if f'{agent.agent_meta["Agent ID"]}_{tid}' in tracks]
+        tids = [
+            tid
+            for tid in agent.tracks.keys()
+            if f'{agent.agent_meta["Agent ID"]}_{tid}' in tracks
+        ]
     else:
         tids = agent.tracks.keys()
-    #loop over each track
+    # loop over each track
     for tid in tids:
         track = agent.tracks[tid]
         _tid = f"{agent.agent_meta['Agent ID']}_{tid}"
-        track.loc[:,f'Code{code}'] = [values.loc[_tid, 'Value']] * len(track)
-    #save the file
+        track.loc[:, f"Code{code}"] = [values.loc[_tid, "Value"]] * len(track)
+    # save the file
     save_pkl(pkl_files[0], agent)
+
 
 ################################################################################

--- a/trackio/geometry.py
+++ b/trackio/geometry.py
@@ -1,666 +1,727 @@
 ################################################################################
 
-from .utils import (read_pkl, 
-                    save_pkl, 
-                    collect_agent_pkls, 
-                    NN_idx2)
+import os
+
+# for dividing by zero in lin alg equations - returns nan anyways, but annoying
+import warnings
 
 import numpy as np
-from pyproj import CRS, Geod
-import os
 import pandas as pd
-from shapely.geometry import Point, LineString
 from inpoly import inpoly2
 from more_itertools import consecutive_groups
+from pyproj import CRS, Geod
+from shapely.geometry import LineString, Point
 from skimage.graph import route_through_array
 
-#for dividing by zero in lin alg equations - returns nan anyways, but annoying
-import warnings
+from .utils import NN_idx2, collect_agent_pkls, read_pkl, save_pkl
+
 warnings.filterwarnings("ignore", category=RuntimeWarning)
 
 ################################################################################
 
+
 def interpolate_dynamic_data(track, newx, oldx):
-    #setup dict
+    # setup dict
     out = {}
-    #get dtypes
+    # get dtypes
     dtypes = track.dtypes
-    #loop over columns
+    # loop over columns
     for col in track.columns:
-        #if numeric
+        # if numeric
         if pd.api.types.is_numeric_dtype(dtypes[col]):
             out[col] = np.interp(newx, oldx, track[col].values)
-        #if datetime
-        elif col == 'Time':
-            out[col] = pd.to_datetime(np.interp(newx, 
-                                                oldx, 
-                                                track[col].astype(np.int64)))
-        #if boolean
+        # if datetime
+        elif col == "Time":
+            out[col] = pd.to_datetime(
+                np.interp(newx, oldx, track[col].astype(np.int64))
+            )
+        # if boolean
         elif pd.api.types.is_bool_dtype(dtypes[col]):
             out[col] = np.interp(newx, oldx, track[col].values).astype(bool)
-        #if string
+        # if string
         else:
-            #map to ints
+            # map to ints
             uniq = track[col].unique()
-            mapper = {u:i for i,u in enumerate(uniq)}
+            mapper = {u: i for i, u in enumerate(uniq)}
             inv_mapper = dict(zip(mapper.values(), mapper.keys()))
             dat = track[col].apply(lambda x: mapper.get(x)).values
-            #interpolate the ints
+            # interpolate the ints
             newdat = np.interp(newx, oldx, dat).round().astype(int)
             out[col] = list(map(lambda x: inv_mapper.get(x), newdat))
-    #return dataframe
+    # return dataframe
     return pd.DataFrame(out)
 
-def points_to_coursing(x, y, crs, method='forward'):
+
+def points_to_coursing(x, y, crs, method="forward"):
     if CRS(crs).is_geographic:
         geod = Geod(ellps="WGS84")
-        courses, _, _ = geod.inv(x[:-1], y[:-1], x[1:], y[1:])     
+        courses, _, _ = geod.inv(x[:-1], y[:-1], x[1:], y[1:])
     else:
         dx = np.diff(x)
         dy = np.diff(y)
         courses = np.degrees(np.arctan2(dx, dy))
-    if method == 'forward':
+    if method == "forward":
         courses = np.hstack([courses, courses[-1:]])
-    elif method == 'backward':
+    elif method == "backward":
         courses = np.hstack([courses[:1], courses])
     else:
         c1 = np.hstack([courses, courses[-1:]])
         c2 = np.hstack([courses[:1], courses])
-        courses = (c1+c2)/2
+        courses = (c1 + c2) / 2
     return courses % 360
-        
+
+
 def decimate(points, epsilon):
     # get the start and end points
     start = np.tile(np.expand_dims(points[0], axis=0), (points.shape[0], 1))
     end = np.tile(np.expand_dims(points[-1], axis=0), (points.shape[0], 1))
     # find distance from other_points to line formed by start and end
-    dist_point_to_line = np.abs(np.cross(end - start, points - start, axis=-1)) / np.linalg.norm(end - start, axis=-1)
+    dist_point_to_line = np.abs(
+        np.cross(end - start, points - start, axis=-1)
+    ) / np.linalg.norm(end - start, axis=-1)
     # get the index of the points with the largest distance
     max_idx = np.argmax(dist_point_to_line)
     max_value = dist_point_to_line[max_idx]
     result = []
     if max_value > epsilon:
-        partial_results_left = decimate(points[:max_idx+1], epsilon)
-        result += [list(i) for i in partial_results_left if list(i) not in result]
+        partial_results_left = decimate(points[: max_idx + 1], epsilon)
+        result += [
+            list(i) for i in partial_results_left if list(i) not in result
+        ]
         partial_results_right = decimate(points[max_idx:], epsilon)
-        result += [list(i) for i in partial_results_right if list(i) not in result]
+        result += [
+            list(i) for i in partial_results_right if list(i) not in result
+        ]
     else:
         result += [points[0], points[-1]]
     pass
     return np.array(result)
 
-def characteristic_indices(x, y, time, speed, coursing,
-                            stop_threshold=0.15,
-                            turn_threshold=22.5,
-                            min_distance=500,
-                            max_distance=20000,
-                            min_stop_duration=1800):
-    #get the diffs
-    dx = (np.diff(x)**2 + np.diff(y)**2)**0.5
+
+def characteristic_indices(
+    x,
+    y,
+    time,
+    speed,
+    coursing,
+    stop_threshold=0.15,
+    turn_threshold=22.5,
+    min_distance=500,
+    max_distance=20000,
+    min_stop_duration=1800,
+):
+    # get the diffs
+    dx = (np.diff(x) ** 2 + np.diff(y) ** 2) ** 0.5
     dturn = np.diff(coursing)
-    #find the stops
+    # find the stops
     stops = np.nonzero(speed <= stop_threshold)[0]
-    #group the stops
+    # group the stops
     stop_ids = [list(g) for g in consecutive_groups(stops)]
     stop_ids = [[g[0], g[-1]] for g in stop_ids]
-    #remove stops less than threshold
+    # remove stops less than threshold
     for i in range(len(stop_ids)):
         stop = stop_ids[i]
-        if (time[stop[1]] - time[stop[0]]).total_seconds() <= min_stop_duration:
+        if (
+            time[stop[1]] - time[stop[0]]
+        ).total_seconds() <= min_stop_duration:
             stop_ids[i] = stop[1:]
-    #combine end pts, stop pts
-    stop_ids = [[0]] + stop_ids + [[len(time)-1]]
-    #loop over gaps between stops
+    # combine end pts, stop pts
+    stop_ids = [[0]] + stop_ids + [[len(time) - 1]]
+    # loop over gaps between stops
     keeps = []
-    for sid in range(len(stop_ids)-1):
-        #get last point of current stop, first point of next - this is the segment i:j
-        stop_groups = stop_ids[sid], stop_ids[sid+1]
+    for sid in range(len(stop_ids) - 1):
+        # get last point of current stop, first point of next - this is the segment i:j
+        stop_groups = stop_ids[sid], stop_ids[sid + 1]
         i = stop_groups[0][-1]
         j = stop_groups[1][0]
-        #iterate through the segment
+        # iterate through the segment
         while i < j:
-            #get idx along segment at which max_distance met
+            # get idx along segment at which max_distance met
             dxs = dx[i:j].copy()
             dxs[0] = 0
             dist_idx = sum(np.cumsum(dxs) < max_distance) + i
-            #get idx along segment at which turn_threshold is met
+            # get idx along segment at which turn_threshold is met
             dturns = dturn[i:j].copy()
-            dturns[0] = 0 
+            dturns[0] = 0
             turn_idx = sum(np.abs(np.cumsum(dturns)) < turn_threshold) + i
-            #if small segment and no turns
+            # if small segment and no turns
             if dist_idx == j and turn_idx == i:
-                #just connect to the next stop
+                # just connect to the next stop
                 break
             else:
-                #exceeds max distance before turning
+                # exceeds max distance before turning
                 if dist_idx <= turn_idx and turn_idx != i:
-                    #set index to dist index
+                    # set index to dist index
                     keep = dist_idx
-                #turns before max distance is reached
+                # turns before max distance is reached
                 elif turn_idx <= dist_idx and dist_idx != i:
-                    #calc distance along this segment
-                    dist = sum(dxs[:turn_idx-i])
-                    #if distance less than min seg distance
+                    # calc distance along this segment
+                    dist = sum(dxs[: turn_idx - i])
+                    # if distance less than min seg distance
                     if dist <= min_distance:
-                        #short small turns, skip to dist index
+                        # short small turns, skip to dist index
                         keep = dist_idx
                     else:
-                        #long enough turn, set to turn index
+                        # long enough turn, set to turn index
                         keep = turn_idx
-                #if longer than max distance and no turns
+                # if longer than max distance and no turns
                 elif dist_idx > i:
-                    #set to dist index
+                    # set to dist index
                     keep = dist_idx
-                #if turns but doesnt cross distance threshold
+                # if turns but doesnt cross distance threshold
                 elif turn_idx > i:
-                    #skip to next stop
+                    # skip to next stop
                     break
-                #exceeds distance and turn threshold at same time
+                # exceeds distance and turn threshold at same time
                 else:
-                    #set to either
+                    # set to either
                     keep = dist_idx
-                #reset i, append characteristic id to keeps
+                # reset i, append characteristic id to keeps
                 i = keep
                 keeps.append(keep)
-    #resort the keeps and stop ids
+    # resort the keeps and stop ids
     keeps = sorted(set((keeps + [s for sublist in stop_ids for s in sublist])))
     return keeps
 
-def simplified_stop_indices(x, y, time, speed, 
-                           stop_threshold, 
-                           min_stop_duration,
-                           max_drift_distance):
-    #find the stops
+
+def simplified_stop_indices(
+    x, y, time, speed, stop_threshold, min_stop_duration, max_drift_distance
+):
+    # find the stops
     stops = np.nonzero(speed <= stop_threshold)[0]
-    #group the stops
+    # group the stops
     stop_ids = [list(g) for g in consecutive_groups(stops)]
     stop_ids = [s for s in stop_ids if len(s) > 1]
-    #remove stops less than duration threshold
-    stop_ids = [s for s in stop_ids 
-                if (time[s[-1]] - time[s[0]]).total_seconds() >= min_stop_duration]
-    #check for long drifting stops, keep points beyond drift threhsold
+    # remove stops less than duration threshold
+    stop_ids = [
+        s
+        for s in stop_ids
+        if (time[s[-1]] - time[s[0]]).total_seconds() >= min_stop_duration
+    ]
+    # check for long drifting stops, keep points beyond drift threhsold
     keeps = []
     for stop in stop_ids:
         i = stop[0]
         j = stop[-1]
         while i < j:
             keeps.append(i)
-            dists = ((x[i:j]-x[i])**2 + (y[i:j]-y[i])**2)**0.5
+            dists = ((x[i:j] - x[i]) ** 2 + (y[i:j] - y[i]) ** 2) ** 0.5
             dist_idx = np.nonzero(dists >= max_drift_distance)[0]
             if len(dist_idx) == 0:
                 i = j
             else:
                 i += dist_idx[0] + 1
-        keeps.append(j)    
-    #reduce but include drift points
+        keeps.append(j)
+    # reduce but include drift points
     stop_ids = [[s for s in sublist if s in keeps] for sublist in stop_ids]
-    #get ids to return
+    # get ids to return
     return_ids = list(range(len(x)))
     for stop in stop_ids:
-        for i in range(stop[0], stop[-1]+1):
+        for i in range(stop[0], stop[-1] + 1):
             if i in stop:
                 pass
             else:
                 return_ids.pop(return_ids.index(i))
     return return_ids
 
-def reproject_crs(transformer, 
-                  out_path, 
-                  args):
-    #split args
+
+def reproject_crs(transformer, out_path, args):
+    # split args
     pkl_files, tracks = args
-    #if there are specific tracks
+    # if there are specific tracks
     if len(tracks) > 0:
         for pkl_file in pkl_files:
             refresh = False
             agent = read_pkl(pkl_file)
-            tids = [tid for tid in agent.tracks.keys() 
-                    if f'{agent.agent_meta["Agent ID"]}_{tid}' in tracks]
+            tids = [
+                tid
+                for tid in agent.tracks.keys()
+                if f'{agent.agent_meta["Agent ID"]}_{tid}' in tracks
+            ]
             for tid in tids:
-                oldx, oldy = (agent.tracks[tid]['X'].values, 
-                              agent.tracks[tid]['Y'].values)
-                newx, newy = transformer.transform(oldx, oldy)  
-                agent.tracks[tid]['X'] = newx
-                agent.tracks[tid]['Y'] = newy
+                oldx, oldy = (
+                    agent.tracks[tid]["X"].values,
+                    agent.tracks[tid]["Y"].values,
+                )
+                newx, newy = transformer.transform(oldx, oldy)
+                agent.tracks[tid]["X"] = newx
+                agent.tracks[tid]["Y"] = newy
                 refresh = True
-            #save the agent back
+            # save the agent back
             if refresh:
-                out_file = f'{out_path}/{os.path.basename(pkl_file)}'
+                out_file = f"{out_path}/{os.path.basename(pkl_file)}"
                 save_pkl(out_file, agent)
-    #if entire agents
+    # if entire agents
     else:
         for pkl_file in pkl_files:
-            #read agent
+            # read agent
             agent = read_pkl(pkl_file)
-            #get split ids
+            # get split ids
             split_ids = np.cumsum([len(t) for t in agent.tracks.values()])
-            #get old coordinates
-            oldx = agent.data['X']
-            oldy = agent.data['Y']
-            newx, newy = transformer.transform(oldx, oldy)  
-            #if split
+            # get old coordinates
+            oldx = agent.data["X"]
+            oldy = agent.data["Y"]
+            newx, newy = transformer.transform(oldx, oldy)
+            # if split
             if agent._data is None:
                 tx = np.split(newx, split_ids)
                 ty = np.split(newy, split_ids)
                 for i, tid in enumerate(agent.tracks.keys()):
-                    agent.tracks[tid]['X'] = tx[i]
-                    agent.tracks[tid]['Y'] = ty[i]
-            #if not split (still just points)
+                    agent.tracks[tid]["X"] = tx[i]
+                    agent.tracks[tid]["Y"] = ty[i]
+            # if not split (still just points)
             else:
-                agent._data['X'] = newx
-                agent._data['Y'] = newy
-            #save the agent back
-            out_file = f'{out_path}/{os.path.basename(pkl_file)}'
+                agent._data["X"] = newx
+                agent._data["Y"] = newy
+            # save the agent back
+            out_file = f"{out_path}/{os.path.basename(pkl_file)}"
             save_pkl(out_file, agent)
 
-def resample_spacing(spacing, 
-                     out_path,
-                     args):
-    #split args
+
+def resample_spacing(spacing, out_path, args):
+    # split args
     pkl_files, tracks = args
-    #read split agent file
+    # read split agent file
     agent = collect_agent_pkls(pkl_files)
-    #reduce to tracks of interest
+    # reduce to tracks of interest
     if len(tracks) > 0:
-        tids = [tid for tid in agent.tracks.keys() 
-                if f'{agent.agent_meta["Agent ID"]}_{tid}' in tracks]
+        tids = [
+            tid
+            for tid in agent.tracks.keys()
+            if f'{agent.agent_meta["Agent ID"]}_{tid}' in tracks
+        ]
     else:
         tids = agent.tracks.keys()
-    #loop over tracks and resample
+    # loop over tracks and resample
     refresh = False
     for tid in tids:
         track = agent.tracks[tid]
-        #if only 1 point
+        # if only 1 point
         if len(track) == 1:
             continue
-        #if multiple points
-        else:       
-            xd = np.diff(track['X'])
-            yd = np.diff(track['Y'])
-            dist = np.sqrt(xd ** 2 + yd ** 2)
+        # if multiple points
+        else:
+            xd = np.diff(track["X"])
+            yd = np.diff(track["Y"])
+            dist = np.sqrt(xd**2 + yd**2)
             u = np.cumsum(dist)
             u = np.hstack([[0], u])
             total_dist = u[-1]
-            #if total distance of track <= new spacing
+            # if total distance of track <= new spacing
             if total_dist <= spacing:
-                continue #if total dist less than spacing
+                continue  # if total dist less than spacing
             else:
-                refresh = True  
-                #get the new cumsum
-                t = np.hstack([np.arange(0, total_dist, spacing), 
-                               [total_dist]])
-                #interpolate the other attributes back
+                refresh = True
+                # get the new cumsum
+                t = np.hstack(
+                    [np.arange(0, total_dist, spacing), [total_dist]]
+                )
+                # interpolate the other attributes back
                 new_track = interpolate_dynamic_data(track, t, u)
-                #update the track dataframe
+                # update the track dataframe
                 agent.tracks[tid] = new_track
     if refresh:
-        #save the agent back
-        out_file = f'{out_path}/{os.path.basename(pkl_files[0])}'
-        save_pkl(out_file, agent) 
+        # save the agent back
+        out_file = f"{out_path}/{os.path.basename(pkl_files[0])}"
+        save_pkl(out_file, agent)
 
-def resample_time(seconds, 
-                  out_path, 
-                  args):
-    #split args
+
+def resample_time(seconds, out_path, args):
+    # split args
     pkl_files, tracks = args
-    #read split agent file
+    # read split agent file
     agent = collect_agent_pkls(pkl_files)
-    #reduce to tracks of interest
+    # reduce to tracks of interest
     if len(tracks) > 0:
-        tids = [tid for tid in agent.tracks.keys() 
-                if f'{agent.agent_meta["Agent ID"]}_{tid}' in tracks]
+        tids = [
+            tid
+            for tid in agent.tracks.keys()
+            if f'{agent.agent_meta["Agent ID"]}_{tid}' in tracks
+        ]
     else:
         tids = agent.tracks.keys()
-    #respace the coordinates
+    # respace the coordinates
     refresh = False
     for tid in tids:
         track = agent.tracks[tid]
-        #get the time axis
-        t = track['Time'].values.astype(np.int64)/1e9 #to seconds
+        # get the time axis
+        t = track["Time"].values.astype(np.int64) / 1e9  # to seconds
         total_seconds = t[-1] - t[0]
-        #if only one point
+        # if only one point
         if len(t) == 1:
             continue
-        #if multiple points
-        else:       
-            #if total duration <= new spacing  
+        # if multiple points
+        else:
+            # if total duration <= new spacing
             if total_seconds <= seconds:
                 continue
             else:
                 refresh = True
-                #get the new cumsum time
-                tq = np.hstack([np.arange(t[0], t[-1], seconds), t[-1:]])               
-                #interpolate the other attributes back
+                # get the new cumsum time
+                tq = np.hstack([np.arange(t[0], t[-1], seconds), t[-1:]])
+                # interpolate the other attributes back
                 new_track = interpolate_dynamic_data(track, tq, t)
-                #update the track dataframe
+                # update the track dataframe
                 agent.tracks[tid] = new_track
     if refresh:
-        #save the agent back
-        out_file = f'{out_path}/{os.path.basename(pkl_files[0])}'
-        save_pkl(out_file, agent) 
-    
-def resample_time_global(time, 
-                         out_path, 
-                         args):
-    #split args
+        # save the agent back
+        out_file = f"{out_path}/{os.path.basename(pkl_files[0])}"
+        save_pkl(out_file, agent)
+
+
+def resample_time_global(time, out_path, args):
+    # split args
     pkl_files, tracks = args
-    #read split agent file
+    # read split agent file
     agent = collect_agent_pkls(pkl_files)
-    #reduce to tracks of interest
+    # reduce to tracks of interest
     if len(tracks) > 0:
-        tids = [tid for tid in agent.tracks.keys() 
-                if f'{agent.agent_meta["Agent ID"]}_{tid}' in tracks]
+        tids = [
+            tid
+            for tid in agent.tracks.keys()
+            if f'{agent.agent_meta["Agent ID"]}_{tid}' in tracks
+        ]
     else:
         tids = agent.tracks.keys()
-    #respace the coordinates
+    # respace the coordinates
     for tid in tids:
         track = agent.tracks[tid]
-        #get the time axis
-        t = track['Time'].values.astype(np.int64)/1e9 #to seconds
-        #if there's only 1 ping, just shift the time
+        # get the time axis
+        t = track["Time"].values.astype(np.int64) / 1e9  # to seconds
+        # if there's only 1 ping, just shift the time
         if len(t) == 1:
             new_time_id = np.argmin(np.abs((time - t[0])))
-            track.loc[:,'Time'] = pd.to_datetime([time[new_time_id]], 
-                                                 unit='s')
-        #if theres more than one ping
+            track.loc[:, "Time"] = pd.to_datetime(
+                [time[new_time_id]], unit="s"
+            )
+        # if theres more than one ping
         else:
-            #if track timesteps cross over multiple time gaps   
-            resample_times = time[(time>=t[0]) & (time<=t[-1])]
-            #if all track pings are contained within one time gap
-            if len(resample_times)==0:
+            # if track timesteps cross over multiple time gaps
+            resample_times = time[(time >= t[0]) & (time <= t[-1])]
+            # if all track pings are contained within one time gap
+            if len(resample_times) == 0:
                 new_time_ids = [np.argmin(np.abs((time - tt))) for tt in t]
                 new_time_ids = sorted(np.unique(new_time_ids))
                 resample_times = time[new_time_ids]
-            #interpolate the other attributes back
+            # interpolate the other attributes back
             new_track = interpolate_dynamic_data(track, resample_times, t)
-            new_track['Time'] = pd.to_datetime(resample_times, unit='s')
-            #update the track dataframe
+            new_track["Time"] = pd.to_datetime(resample_times, unit="s")
+            # update the track dataframe
             agent.tracks[tid] = new_track
-    #save the agent back
-    out_file = f'{out_path}/{os.path.basename(pkl_files[0])}'
-    save_pkl(out_file, agent) 
+    # save the agent back
+    out_file = f"{out_path}/{os.path.basename(pkl_files[0])}"
+    save_pkl(out_file, agent)
 
-def compute_coursing(method, 
-                     crs, 
-                     out_path,
-                     args):
-    #split args
+
+def compute_coursing(method, crs, out_path, args):
+    # split args
     pkl_files, tracks = args
-    #read split agent file
+    # read split agent file
     agent = collect_agent_pkls(pkl_files)
-    #reduce to tracks of interest
+    # reduce to tracks of interest
     if len(tracks) > 0:
-        tids = [tid for tid in agent.tracks.keys() 
-                if f'{agent.agent_meta["Agent ID"]}_{tid}' in tracks]
+        tids = [
+            tid
+            for tid in agent.tracks.keys()
+            if f'{agent.agent_meta["Agent ID"]}_{tid}' in tracks
+        ]
     else:
         tids = agent.tracks.keys()
-    #loop over each track, recompute coursing
+    # loop over each track, recompute coursing
     for tid in tids:
         track = agent.tracks[tid]
         if len(track) == 1:
             coursing = [np.nan]
         else:
-            #recompute coursing based on points
-            coursing = points_to_coursing(track['X'].values, 
-                                          track['Y'].values, 
-                                          crs,
-                                          method)
-        track.loc[:, 'Coursing'] = coursing  
-    #save the agent back
-    out_file = f'{out_path}/{os.path.basename(pkl_files[0])}'
-    save_pkl(out_file, agent) 
+            # recompute coursing based on points
+            coursing = points_to_coursing(
+                track["X"].values, track["Y"].values, crs, method
+            )
+        track.loc[:, "Coursing"] = coursing
+    # save the agent back
+    out_file = f"{out_path}/{os.path.basename(pkl_files[0])}"
+    save_pkl(out_file, agent)
 
-def compute_turning_rate(method, 
-                         out_path, 
-                         args):
-    #split args
+
+def compute_turning_rate(method, out_path, args):
+    # split args
     pkl_files, tracks = args
-    #read split agent file
+    # read split agent file
     agent = collect_agent_pkls(pkl_files)
-    #reduce to tracks of interest
+    # reduce to tracks of interest
     if len(tracks) > 0:
-        tids = [tid for tid in agent.tracks.keys() 
-                if f'{agent.agent_meta["Agent ID"]}_{tid}' in tracks]
+        tids = [
+            tid
+            for tid in agent.tracks.keys()
+            if f'{agent.agent_meta["Agent ID"]}_{tid}' in tracks
+        ]
     else:
         tids = agent.tracks.keys()
-    #loop over each track, recompute coursing
+    # loop over each track, recompute coursing
     for tid in tids:
         track = agent.tracks[tid]
         if len(track) == 1:
             turn = [np.nan]
         else:
-            coursing = track['Coursing'].values
+            coursing = track["Coursing"].values
             dc = np.diff(coursing)
-            dt = np.diff(track['Time'].values) / np.timedelta64(1, 's')
-            turn = dc/dt
-            if method == 'forward':
+            dt = np.diff(track["Time"].values) / np.timedelta64(1, "s")
+            turn = dc / dt
+            if method == "forward":
                 turn = np.hstack([turn, turn[-1:]])
-            elif method == 'backward':
+            elif method == "backward":
                 turn = np.hstack([turn[:1], turn])
             else:
                 turn1 = np.hstack([turn, turn[-1:]])
                 turn2 = np.hstack([turn[:1], turn])
-                turn = (turn1+turn2)/2
-        track.loc[:, 'Turning Rate'] = turn
-    #save the agent back
-    out_file = f'{out_path}/{os.path.basename(pkl_files[0])}'
-    save_pkl(out_file, agent) 
+                turn = (turn1 + turn2) / 2
+        track.loc[:, "Turning Rate"] = turn
+    # save the agent back
+    out_file = f"{out_path}/{os.path.basename(pkl_files[0])}"
+    save_pkl(out_file, agent)
 
-def compute_speed(method, 
-                  out_path, 
-                  args):
-    #split args
+
+def compute_speed(method, out_path, args):
+    # split args
     pkl_files, tracks = args
-    #read split agent file
+    # read split agent file
     agent = collect_agent_pkls(pkl_files)
-    #reduce to tracks of interest
+    # reduce to tracks of interest
     if len(tracks) > 0:
-        tids = [tid for tid in agent.tracks.keys() 
-                if f'{agent.agent_meta["Agent ID"]}_{tid}' in tracks]
+        tids = [
+            tid
+            for tid in agent.tracks.keys()
+            if f'{agent.agent_meta["Agent ID"]}_{tid}' in tracks
+        ]
     else:
         tids = agent.tracks.keys()
-    #loop over each track, recompute coursing
+    # loop over each track, recompute coursing
     for tid in tids:
         track = agent.tracks[tid]
         if len(track) == 1:
             speed = [np.nan]
         else:
-            coords = track[['X','Y']].values
-            dx = np.diff(coords[:,0])
-            dy = np.diff(coords[:,1])
-            dr = np.sqrt(dx**2+dy**2)
-            dt = np.diff(track['Time'].values) / np.timedelta64(1, 's')
-            speed = dr/dt
-            if method == 'forward':
+            coords = track[["X", "Y"]].values
+            dx = np.diff(coords[:, 0])
+            dy = np.diff(coords[:, 1])
+            dr = np.sqrt(dx**2 + dy**2)
+            dt = np.diff(track["Time"].values) / np.timedelta64(1, "s")
+            speed = dr / dt
+            if method == "forward":
                 speed = np.hstack([speed, speed[-1:]])
-            elif method == 'backward':
+            elif method == "backward":
                 speed = np.hstack([speed[:1], speed])
             else:
                 speed1 = np.hstack([speed, speed[-1:]])
                 speed2 = np.hstack([speed[:1], speed])
-                speed = (speed1+speed2)/2
-        track.loc[:,'Speed'] = speed
-    #save the agent back
-    out_file = f'{out_path}/{os.path.basename(pkl_files[0])}'
-    save_pkl(out_file, agent) 
+                speed = (speed1 + speed2) / 2
+        track.loc[:, "Speed"] = speed
+    # save the agent back
+    out_file = f"{out_path}/{os.path.basename(pkl_files[0])}"
+    save_pkl(out_file, agent)
 
-def compute_acceleration(out_path,
-                         method, 
-                         args):
-    #split args
+
+def compute_acceleration(out_path, method, args):
+    # split args
     pkl_files, tracks = args
-    #read split agent file
+    # read split agent file
     agent = collect_agent_pkls(pkl_files)
-    #reduce to tracks of interest
+    # reduce to tracks of interest
     if len(tracks) > 0:
-        tids = [tid for tid in agent.tracks.keys() 
-                if f'{agent.agent_meta["Agent ID"]}_{tid}' in tracks]
+        tids = [
+            tid
+            for tid in agent.tracks.keys()
+            if f'{agent.agent_meta["Agent ID"]}_{tid}' in tracks
+        ]
     else:
         tids = agent.tracks.keys()
-    #loop over each track, recompute acceleration
+    # loop over each track, recompute acceleration
     for tid in tids:
         track = agent.tracks[tid]
         if len(track) == 1:
             a = [np.nan]
         else:
-            dt = np.diff(track['Time'].values) / np.timedelta64(1, 's')
-            ds = np.diff(track['Speed'].values)
-            a = ds/dt
-            if method == 'forward':
+            dt = np.diff(track["Time"].values) / np.timedelta64(1, "s")
+            ds = np.diff(track["Speed"].values)
+            a = ds / dt
+            if method == "forward":
                 a = np.hstack([a, a[-1:]])
-            elif method == 'backward':
+            elif method == "backward":
                 a = np.hstack([a[:1], a])
             else:
                 a1 = np.hstack([a, a[-1:]])
                 a2 = np.hstack([a[:1], a])
-                a = (a1+a2)/2
-        track.loc[:,'Acceleration'] = a
-    #save the agent back
-    out_file = f'{out_path}/{os.path.basename(pkl_files[0])}'
-    save_pkl(out_file, agent) 
+                a = (a1 + a2) / 2
+        track.loc[:, "Acceleration"] = a
+    # save the agent back
+    out_file = f"{out_path}/{os.path.basename(pkl_files[0])}"
+    save_pkl(out_file, agent)
 
-def compute_distance_travelled(out_path,
-                               relative,
-                               args):
-    #split args
+
+def compute_distance_travelled(out_path, relative, args):
+    # split args
     pkl_files, tracks = args
-    #read split agent file
+    # read split agent file
     agent = collect_agent_pkls(pkl_files)
-    #reduce to tracks of interest
+    # reduce to tracks of interest
     if len(tracks) > 0:
-        tids = [tid for tid in agent.tracks.keys() 
-                if f'{agent.agent_meta["Agent ID"]}_{tid}' in tracks]
+        tids = [
+            tid
+            for tid in agent.tracks.keys()
+            if f'{agent.agent_meta["Agent ID"]}_{tid}' in tracks
+        ]
     else:
         tids = agent.tracks.keys()
-    #loop over each track, recompute acceleration
+    # loop over each track, recompute acceleration
     for tid in tids:
         track = agent.tracks[tid]
         if len(track) == 1:
             dist = [0]
         else:
-            dx = np.diff(track['X'].values)
-            dy = np.diff(track['Y'].values)
-            dr = (dx**2 + dy**2)**0.5
+            dx = np.diff(track["X"].values)
+            dy = np.diff(track["Y"].values)
+            dr = (dx**2 + dy**2) ** 0.5
             dist = np.hstack([[0], np.cumsum(dr)])
-        #if relative 0-1
+        # if relative 0-1
         if relative:
-            dist = dist/dist.max()
-        track.loc[:,'Distance Travelled'] = dist
-    #save the agent back
-    out_file = f'{out_path}/{os.path.basename(pkl_files[0])}'
-    save_pkl(out_file, agent) 
+            dist = dist / dist.max()
+        track.loc[:, "Distance Travelled"] = dist
+    # save the agent back
+    out_file = f"{out_path}/{os.path.basename(pkl_files[0])}"
+    save_pkl(out_file, agent)
+
 
 def define_circle(p1, p2, p3):
     # Calculate the distances (a, b, c) between each pair of points
     a = np.linalg.norm(p2 - p3, axis=1)
     b = np.linalg.norm(p1 - p3, axis=1)
     c = np.linalg.norm(p1 - p2, axis=1)
-    
+
     # Calculate the semi-perimeter
     s = (a + b + c) / 2
-    
+
     # Calculate the area of the triangle using Heron's formula
     area = np.sqrt(s * (s - a) * (s - b) * (s - c))
-    
+
     # Calculate the radius of the circumcircle
     radius = (a * b * c) / (4 * area)
-    
+
     # Handle cases where the area is zero (collinear points) to avoid division by zero
     radius = np.where(area == 0, np.inf, radius)
     return radius
 
-def compute_radius_of_curvature(out_path,
-                                args):
-    #split args
+
+def compute_radius_of_curvature(out_path, args):
+    # split args
     pkl_files, tracks = args
-    #read split agent file
+    # read split agent file
     agent = collect_agent_pkls(pkl_files)
-    #reduce to tracks of interest
+    # reduce to tracks of interest
     if len(tracks) > 0:
-        tids = [tid for tid in agent.tracks.keys() 
-                if f'{agent.agent_meta["Agent ID"]}_{tid}' in tracks]
+        tids = [
+            tid
+            for tid in agent.tracks.keys()
+            if f'{agent.agent_meta["Agent ID"]}_{tid}' in tracks
+        ]
     else:
         tids = agent.tracks.keys()
-    #loop over each track, recompute acceleration
+    # loop over each track, recompute acceleration
     for tid in tids:
         track = agent.tracks[tid]
         if len(track) < 3:
-            radius = [np.nan]*len(track)
+            radius = [np.nan] * len(track)
         else:
-            p1 = track[['X','Y']].iloc[:-2][['X','Y']].values
-            p2 = track[['X','Y']].iloc[1:-1][['X','Y']].values
-            p3 = track[['X','Y']].iloc[2:][['X','Y']].values
+            p1 = track[["X", "Y"]].iloc[:-2][["X", "Y"]].values
+            p2 = track[["X", "Y"]].iloc[1:-1][["X", "Y"]].values
+            p3 = track[["X", "Y"]].iloc[2:][["X", "Y"]].values
             radius = define_circle(p1, p2, p3)
             radius = np.hstack([[np.nan], radius, [np.nan]])
-        track.loc[:,'Radius of Curvature'] = radius
-    #save the agent back
-    out_file = f'{out_path}/{os.path.basename(pkl_files[0])}'
-    save_pkl(out_file, agent) 
-    
-def compute_sinuosity(out_path,
-                      window,
-                      args):
-    #split args
+        track.loc[:, "Radius of Curvature"] = radius
+    # save the agent back
+    out_file = f"{out_path}/{os.path.basename(pkl_files[0])}"
+    save_pkl(out_file, agent)
+
+
+def compute_sinuosity(out_path, window, args):
+    # split args
     pkl_files, tracks = args
-    #read split agent file
+    # read split agent file
     agent = collect_agent_pkls(pkl_files)
-    #reduce to tracks of interest
+    # reduce to tracks of interest
     if len(tracks) > 0:
-        tids = [tid for tid in agent.tracks.keys() 
-                if f'{agent.agent_meta["Agent ID"]}_{tid}' in tracks]
+        tids = [
+            tid
+            for tid in agent.tracks.keys()
+            if f'{agent.agent_meta["Agent ID"]}_{tid}' in tracks
+        ]
     else:
         tids = agent.tracks.keys()
-    #loop over each track, recompute acceleration
+    # loop over each track, recompute acceleration
     for tid in tids:
         track = agent.tracks[tid]
         if len(track) < window:
-            sin = [np.nan]*len(track)
+            sin = [np.nan] * len(track)
         else:
             sin = []
-            start = int((window-1)/2)
-            end = int(len(track)-((window-1)/2))
-            coords = track[['X','Y']].values
+            start = int((window - 1) / 2)
+            end = int(len(track) - ((window - 1) / 2))
+            coords = track[["X", "Y"]].values
             for i in range(start, end):
-                istart = i-(int((window-1)/2))
-                iend = i+(int((window-1)/2))+1
-                segment_length = np.sum((np.diff(coords[istart:iend,0])**2 + np.diff(coords[istart:iend,1])**2)**0.5)
-                segment_effective = ((coords[iend-1,0] - coords[istart,0])**2 + (coords[iend-1,1] - coords[istart,1])**2)**0.5
+                istart = i - (int((window - 1) / 2))
+                iend = i + (int((window - 1) / 2)) + 1
+                segment_length = np.sum(
+                    (
+                        np.diff(coords[istart:iend, 0]) ** 2
+                        + np.diff(coords[istart:iend, 1]) ** 2
+                    )
+                    ** 0.5
+                )
+                segment_effective = (
+                    (coords[iend - 1, 0] - coords[istart, 0]) ** 2
+                    + (coords[iend - 1, 1] - coords[istart, 1]) ** 2
+                ) ** 0.5
                 _sin = segment_length / segment_effective
                 sin.append(_sin)
-            sin = [np.nan]*int((window-1)/2) + sin + [np.nan]*int((window-1)/2)
-        track.loc[:,'Sinuosity'] = sin
-    #save the agent back
-    out_file = f'{out_path}/{os.path.basename(pkl_files[0])}'
-    save_pkl(out_file, agent) 
+            sin = (
+                [np.nan] * int((window - 1) / 2)
+                + sin
+                + [np.nan] * int((window - 1) / 2)
+            )
+        track.loc[:, "Sinuosity"] = sin
+    # save the agent back
+    out_file = f"{out_path}/{os.path.basename(pkl_files[0])}"
+    save_pkl(out_file, agent)
 
-def smooth_corners(refinements, 
-                   out_path, 
-                   args):
-    #DETECT THE CORNERS BASED ON THRESHOLD??
-    #split args
+
+def smooth_corners(refinements, out_path, args):
+    # DETECT THE CORNERS BASED ON THRESHOLD??
+    # split args
     pkl_files, tracks = args
-    #read split agent file
+    # read split agent file
     agent = collect_agent_pkls(pkl_files)
-    #reduce to tracks of interest
+    # reduce to tracks of interest
     if len(tracks) > 0:
-        tids = [tid for tid in agent.tracks.keys() 
-                if f'{agent.agent_meta["Agent ID"]}_{tid}' in tracks]
+        tids = [
+            tid
+            for tid in agent.tracks.keys()
+            if f'{agent.agent_meta["Agent ID"]}_{tid}' in tracks
+        ]
     else:
         tids = agent.tracks.keys()
-    #loop over each track, smooth the corners
+    # loop over each track, smooth the corners
     refresh = False
     for tid in tids:
         track = agent.tracks[tid]
-        #if only 1 point
+        # if only 1 point
         if len(track) == 1:
             continue
-        #if 2 points and same
+        # if 2 points and same
         elif len(track) == 2 and start_equals_end(track):
             continue
-        #if multiple points
+        # if multiple points
         else:
             refresh = True
-            coords = track[['X','Y']].values
+            coords = track[["X", "Y"]].values
             for _ in range(refinements):
                 L = coords.repeat(2, axis=0)
                 R = np.empty_like(L)
@@ -669,273 +730,352 @@ def smooth_corners(refinements,
                 R[1:-1:2] = L[2::2]
                 R[-1] = L[-1]
                 coords = L * 0.75 + R * 0.25
-            #get old and new cumsum distances
-            olddist = np.cumsum([[0] + ((np.diff(track['X'])**2 + np.diff(track['Y'])**2)**0.5).tolist()])
-            newdist = np.cumsum([[0] + ((np.diff(coords[:,0])**2 + np.diff(coords[:,1])**2)**0.5).tolist()])
-            #interpolate the other attributes back
+            # get old and new cumsum distances
+            olddist = np.cumsum(
+                [
+                    [0]
+                    + (
+                        (np.diff(track["X"]) ** 2 + np.diff(track["Y"]) ** 2)
+                        ** 0.5
+                    ).tolist()
+                ]
+            )
+            newdist = np.cumsum(
+                [
+                    [0]
+                    + (
+                        (
+                            np.diff(coords[:, 0]) ** 2
+                            + np.diff(coords[:, 1]) ** 2
+                        )
+                        ** 0.5
+                    ).tolist()
+                ]
+            )
+            # interpolate the other attributes back
             new_track = interpolate_dynamic_data(track, newdist, olddist)
-            #update the track dataframe, overwrite the X/Y
+            # update the track dataframe, overwrite the X/Y
             agent.tracks[tid] = new_track
-            new_track.loc[:, 'X'] = coords[:,0]
-            new_track.loc[:, 'Y'] = coords[:,1]
+            new_track.loc[:, "X"] = coords[:, 0]
+            new_track.loc[:, "Y"] = coords[:, 1]
     if refresh:
-        #save the agent back
-        out_file = f'{out_path}/{os.path.basename(pkl_files[0])}'
-        save_pkl(out_file, agent) 
+        # save the agent back
+        out_file = f"{out_path}/{os.path.basename(pkl_files[0])}"
+        save_pkl(out_file, agent)
+
 
 def start_equals_end(track):
-    xstart, ystart = track.iloc[0][['X','Y']].values
-    xend, yend = track.iloc[-1][['X','Y']].values
+    xstart, ystart = track.iloc[0][["X", "Y"]].values
+    xend, yend = track.iloc[-1][["X", "Y"]].values
     if xstart == xend and ystart == yend:
         return True
     else:
         return False
 
-def decimate_tracks(epsilon, 
-                    out_path, 
-                    args):
-    #split args
+
+def decimate_tracks(epsilon, out_path, args):
+    # split args
     pkl_files, tracks = args
-    #read split agent file
+    # read split agent file
     agent = collect_agent_pkls(pkl_files)
-    #reduce to tracks of interest
+    # reduce to tracks of interest
     if len(tracks) > 0:
-        tids = [tid for tid in agent.tracks.keys() 
-                if f'{agent.agent_meta["Agent ID"]}_{tid}' in tracks]
+        tids = [
+            tid
+            for tid in agent.tracks.keys()
+            if f'{agent.agent_meta["Agent ID"]}_{tid}' in tracks
+        ]
     else:
         tids = agent.tracks.keys()
-    #loop over each track, smooth the corners
+    # loop over each track, smooth the corners
     refresh = False
     for tid in tids:
         track = agent.tracks[tid]
-        #if only 1 point
+        # if only 1 point
         if len(track) == 1:
             continue
-        #if 2 points and same
+        # if 2 points and same
         elif len(track) == 2 and start_equals_end(track):
             continue
         else:
             refresh = True
-            _coords = track[['X','Y']].values
+            _coords = track[["X", "Y"]].values
             coords = decimate(_coords, epsilon)
-            #get old and new cumsum distances
-            olddist = np.cumsum([[0] + ((np.diff(_coords[:,0])**2 + np.diff(_coords[:,1])**2)**0.5).tolist()])
-            newdist = np.cumsum([[0] + ((np.diff(coords[:,0])**2 + np.diff(coords[:,1])**2)**0.5).tolist()])
-            #interpolate the other attributes back
+            # get old and new cumsum distances
+            olddist = np.cumsum(
+                [
+                    [0]
+                    + (
+                        (
+                            np.diff(_coords[:, 0]) ** 2
+                            + np.diff(_coords[:, 1]) ** 2
+                        )
+                        ** 0.5
+                    ).tolist()
+                ]
+            )
+            newdist = np.cumsum(
+                [
+                    [0]
+                    + (
+                        (
+                            np.diff(coords[:, 0]) ** 2
+                            + np.diff(coords[:, 1]) ** 2
+                        )
+                        ** 0.5
+                    ).tolist()
+                ]
+            )
+            # interpolate the other attributes back
             new_track = interpolate_dynamic_data(track, newdist, olddist)
-            #update the track dataframe, overwrite the X/Y
+            # update the track dataframe, overwrite the X/Y
             agent.tracks[tid] = new_track
-            new_track.loc[:, 'X'] = coords[:,0]
-            new_track.loc[:, 'Y'] = coords[:,1]
+            new_track.loc[:, "X"] = coords[:, 0]
+            new_track.loc[:, "Y"] = coords[:, 1]
     if refresh:
-        #save the agent back
-        out_file = f'{out_path}/{os.path.basename(pkl_files[0])}'
-        save_pkl(out_file, agent) 
+        # save the agent back
+        out_file = f"{out_path}/{os.path.basename(pkl_files[0])}"
+        save_pkl(out_file, agent)
 
-def characteristic_tracks(stop_threshold,
-                          turn_threshold,
-                          min_distance,
-                          max_distance,
-                          min_stop_duration, 
-                          out_path,
-                          inplace,
-                          args):
-    #split args
+
+def characteristic_tracks(
+    stop_threshold,
+    turn_threshold,
+    min_distance,
+    max_distance,
+    min_stop_duration,
+    out_path,
+    inplace,
+    args,
+):
+    # split args
     pkl_files, tracks = args
-    #read split agent file
+    # read split agent file
     agent = collect_agent_pkls(pkl_files)
-    #reduce to tracks of interest
+    # reduce to tracks of interest
     if len(tracks) > 0:
-        tids = [tid for tid in agent.tracks.keys() 
-                if f'{agent.agent_meta["Agent ID"]}_{tid}' in tracks]
+        tids = [
+            tid
+            for tid in agent.tracks.keys()
+            if f'{agent.agent_meta["Agent ID"]}_{tid}' in tracks
+        ]
     else:
         tids = agent.tracks.keys()
-    #loop over each track
+    # loop over each track
     for tid in tids:
         track = agent.tracks[tid]
         if len(track) == 1:
             keeps = [0]
-        #if 2 points and same
-        elif len(track) == 2: #and start_equals_end(track):
-            keeps = [0,1]
+        # if 2 points and same
+        elif len(track) == 2:  # and start_equals_end(track):
+            keeps = [0, 1]
         else:
-            #characteristic indices
-            keeps = characteristic_indices(track['X'],
-                                           track['Y'],
-                                           track['Time'],
-                                           track['Speed'],
-                                           track['Coursing'],
-                                           stop_threshold,
-                                           turn_threshold,
-                                           min_distance,
-                                           max_distance,
-                                           min_stop_duration)
-        #add to track dataframe
-        track.loc[:, 'Characteristic'] = False
-        track.loc[keeps, 'Characteristic'] = True
-        #if modifying data in place
+            # characteristic indices
+            keeps = characteristic_indices(
+                track["X"],
+                track["Y"],
+                track["Time"],
+                track["Speed"],
+                track["Coursing"],
+                stop_threshold,
+                turn_threshold,
+                min_distance,
+                max_distance,
+                min_stop_duration,
+            )
+        # add to track dataframe
+        track.loc[:, "Characteristic"] = False
+        track.loc[keeps, "Characteristic"] = True
+        # if modifying data in place
         if inplace:
-            #if all keepers
+            # if all keepers
             if len(keeps) == len(track):
                 continue
             else:
-                #update the track dataframe
+                # update the track dataframe
                 agent.tracks[tid] = track.iloc[keeps].reset_index(drop=True)
-    #save the agent back
-    out_file = f'{out_path}/{os.path.basename(pkl_files[0])}'
-    save_pkl(out_file, agent) 
+    # save the agent back
+    out_file = f"{out_path}/{os.path.basename(pkl_files[0])}"
+    save_pkl(out_file, agent)
 
-def simplify_stops(stop_threshold,
-                   min_stop_duration, 
-                   max_drift_distance,
-                   out_path,
-                   args):
-    #split args
+
+def simplify_stops(
+    stop_threshold, min_stop_duration, max_drift_distance, out_path, args
+):
+    # split args
     pkl_files, tracks = args
-    #read split agent file
+    # read split agent file
     agent = collect_agent_pkls(pkl_files)
-    #reduce to tracks of interest
+    # reduce to tracks of interest
     if len(tracks) > 0:
-        tids = [tid for tid in agent.tracks.keys() 
-                if f'{agent.agent_meta["Agent ID"]}_{tid}' in tracks]
+        tids = [
+            tid
+            for tid in agent.tracks.keys()
+            if f'{agent.agent_meta["Agent ID"]}_{tid}' in tracks
+        ]
     else:
         tids = agent.tracks.keys()
-    #loop over each track, smooth the corners
+    # loop over each track, smooth the corners
     refresh = False
     for tid in tids:
         track = agent.tracks[tid]
         if len(track) == 1:
             continue
-        #if 2 points and same
+        # if 2 points and same
         elif len(track) == 2 and start_equals_end(track):
             continue
         else:
-            keeps = simplified_stop_indices(track['X'],
-                                            track['Y'],
-                                            track['Time'],
-                                            track['Speed'],
-                                            stop_threshold,
-                                            min_stop_duration,
-                                            max_drift_distance)
-            #if all keepers
+            keeps = simplified_stop_indices(
+                track["X"],
+                track["Y"],
+                track["Time"],
+                track["Speed"],
+                stop_threshold,
+                min_stop_duration,
+                max_drift_distance,
+            )
+            # if all keepers
             if len(keeps) == len(track):
                 continue
             else:
                 refresh = True
-                #update the track dataframe
+                # update the track dataframe
                 agent.tracks[tid] = track.iloc[keeps].reset_index(drop=True)
     if refresh:
-        #save the agent back
-        out_file = f'{out_path}/{os.path.basename(pkl_files[0])}'
-        save_pkl(out_file, agent) 
+        # save the agent back
+        out_file = f"{out_path}/{os.path.basename(pkl_files[0])}"
+        save_pkl(out_file, agent)
 
-def proximity_to_object(shapes, 
-                        data_cols,
-                        meta_cols,
-                        args):
+
+def proximity_to_object(shapes, data_cols, meta_cols, args):
     rows = []
-    #split args
+    # split args
     pkl_files, tracks = args
-    #read split agent file
+    # read split agent file
     agent = collect_agent_pkls(pkl_files)
-    #reduce to tracks of interest
+    # reduce to tracks of interest
     if len(tracks) > 0:
-        tids = [tid for tid in agent.tracks.keys() 
-                if f'{agent.agent_meta["Agent ID"]}_{tid}' in tracks]
+        tids = [
+            tid
+            for tid in agent.tracks.keys()
+            if f'{agent.agent_meta["Agent ID"]}_{tid}' in tracks
+        ]
     else:
         tids = agent.tracks.keys()
-    #loop over each track, get proximity
+    # loop over each track, get proximity
     for tid in tids:
         track = agent.tracks[tid]
-        points1 = track[['X','Y']].values
-        #loop over the different shapes
+        points1 = track[["X", "Y"]].values
+        # loop over the different shapes
         nearests = []
         min_dists = []
         for points2 in shapes:
-            #if both 1 point
-            if len(points1)==1 and len(points2)==1:
-                nearest_points = {'min_dist': ((points2-points1)**2).sum()**0.5,
-                                  'p1': points1[0],
-                                  'p2': points2[0],
-                                  'idx1': 0,
-                                  'idx2': 0,
-                                  'frac1': 0,
-                                  'frac2': 0}
-            #if first is only 1 point
-            elif len(points1)==1:
+            # if both 1 point
+            if len(points1) == 1 and len(points2) == 1:
+                nearest_points = {
+                    "min_dist": ((points2 - points1) ** 2).sum() ** 0.5,
+                    "p1": points1[0],
+                    "p2": points2[0],
+                    "idx1": 0,
+                    "idx2": 0,
+                    "frac1": 0,
+                    "frac2": 0,
+                }
+            # if first is only 1 point
+            elif len(points1) == 1:
                 nearest_points = get_nearest_points(points1, points2)
-            #if second is only 1 point
-            elif len(points2)==1:
+            # if second is only 1 point
+            elif len(points2) == 1:
                 _np = get_nearest_points(points2, points1)
-                new_keys = [k.replace('1','2') if '1' in k 
-                            else  k.replace('2','1') 
-                            for k in _np.keys()]
+                new_keys = [
+                    k.replace("1", "2") if "1" in k else k.replace("2", "1")
+                    for k in _np.keys()
+                ]
                 nearest_points = dict(zip(new_keys, _np.values()))
-            #both are multiple points
+            # both are multiple points
             else:
                 _np1 = get_nearest_points(points1, points2)
                 _np2 = get_nearest_points(points2, points1)
-                if _np2['min_dist'] < _np1['min_dist']:
-                    new_keys = [k.replace('1','2') if '1' in k 
-                            else  k.replace('2','1') 
-                            for k in _np2.keys()]
+                if _np2["min_dist"] < _np1["min_dist"]:
+                    new_keys = [
+                        (
+                            k.replace("1", "2")
+                            if "1" in k
+                            else k.replace("2", "1")
+                        )
+                        for k in _np2.keys()
+                    ]
                     nearest_points = dict(zip(new_keys, _np2.values()))
                 else:
                     nearest_points = _np1
-                #check for intersection
-                _segment1 = points1[nearest_points['idx1']:nearest_points['idx1']+2]
-                _segment2 = points2[nearest_points['idx2']:nearest_points['idx2']+2]
-                #only if both segments (could be end points of the lines)
-                if len(_segment1)>1 and len(_segment2)>1:
+                # check for intersection
+                _segment1 = points1[
+                    nearest_points["idx1"] : nearest_points["idx1"] + 2
+                ]
+                _segment2 = points2[
+                    nearest_points["idx2"] : nearest_points["idx2"] + 2
+                ]
+                # only if both segments (could be end points of the lines)
+                if len(_segment1) > 1 and len(_segment2) > 1:
                     segment1 = LineString(_segment1)
                     segment2 = LineString(_segment2)
-                    #if they intersect
+                    # if they intersect
                     if segment1.intersects(segment2):
                         pt = segment1.intersection(segment2)
-                        #only handle if point, if line then it'll already be zero
+                        # only handle if point, if line then it'll already be zero
                         if isinstance(pt, Point):
-                            #reset the nearest pt info
-                            nearest_points['min_dist'] = 0
-                            nearest_points['p1'] = np.array(pt.xy).T[0]
-                            nearest_points['p2'] = nearest_points['p1']
+                            # reset the nearest pt info
+                            nearest_points["min_dist"] = 0
+                            nearest_points["p1"] = np.array(pt.xy).T[0]
+                            nearest_points["p2"] = nearest_points["p1"]
                             seg1_dist = segment1.length
                             seg2_dist = segment2.length
-                            seg1_dt = ((nearest_points['p1'] - _segment1[0])**2).sum()**0.5 / seg1_dist
-                            seg2_dt = ((nearest_points['p2'] - _segment2[0])**2).sum()**0.5 / seg2_dist
-                            nearest_points['frac1'] = seg1_dt
-                            nearest_points['frac2'] = seg2_dt
-            #append to nearest list
-            nearests.append(nearest_points) 
-            min_dists.append(nearest_points['min_dist'])
-        #get the closest of all shapes
+                            seg1_dt = (
+                                (nearest_points["p1"] - _segment1[0]) ** 2
+                            ).sum() ** 0.5 / seg1_dist
+                            seg2_dt = (
+                                (nearest_points["p2"] - _segment2[0]) ** 2
+                            ).sum() ** 0.5 / seg2_dist
+                            nearest_points["frac1"] = seg1_dt
+                            nearest_points["frac2"] = seg2_dt
+            # append to nearest list
+            nearests.append(nearest_points)
+            min_dists.append(nearest_points["min_dist"])
+        # get the closest of all shapes
         idx = np.argmin(min_dists)
         nearest = nearests[idx]
-        #interpolate the data to this point
-        if 'Time' not in data_cols: data_cols += ['Time']
-        sub = track.iloc[nearest['idx1']:nearest['idx1']+2][data_cols]
-        #if just a point, data already there
-        if len(sub)==1:
+        # interpolate the data to this point
+        if "Time" not in data_cols:
+            data_cols += ["Time"]
+        sub = track.iloc[nearest["idx1"] : nearest["idx1"] + 2][data_cols]
+        # if just a point, data already there
+        if len(sub) == 1:
             row = sub.iloc[0].to_dict()
         else:
-            row = interpolate_dynamic_data(sub, [nearest['frac1']], [0,1]).iloc[0].to_dict()
-        row['X'] = nearest['p1'][0]
-        row['Y'] = nearest['p1'][1]
-        row['geometry'] = Point(nearest['p1'])
-        row['Agent ID'] = agent.agent_meta['Agent ID']
-        row['Track ID'] = agent.track_meta[tid]['Track ID']
-        deltar = ((nearest['p1'] - nearest['p2'])**2).sum()**0.5
-        row['Min Distance'] = deltar
-        #add meta cols
+            row = (
+                interpolate_dynamic_data(sub, [nearest["frac1"]], [0, 1])
+                .iloc[0]
+                .to_dict()
+            )
+        row["X"] = nearest["p1"][0]
+        row["Y"] = nearest["p1"][1]
+        row["geometry"] = Point(nearest["p1"])
+        row["Agent ID"] = agent.agent_meta["Agent ID"]
+        row["Track ID"] = agent.track_meta[tid]["Track ID"]
+        deltar = ((nearest["p1"] - nearest["p2"]) ** 2).sum() ** 0.5
+        row["Min Distance"] = deltar
+        # add meta cols
         for col in meta_cols:
             row[col] = agent.agent_meta[col]
-        #append to master rows
+        # append to master rows
         rows.append(row)
     return rows
 
+
 def get_nearest_points(points1, points2):
     min_dist = 1e9
-    min_p1 = (0,0)
-    min_p2 = (0,0)
+    min_p1 = (0, 0)
+    min_p2 = (0, 0)
     min_i = 0
     min_j = 0
     frac_i = 0
@@ -943,31 +1083,37 @@ def get_nearest_points(points1, points2):
     updated = False
     for i in range(len(points1)):
         P = points1[i]
-        for j in range(len(points2)-1):
-            segment = points2[j:j+2]
+        for j in range(len(points2) - 1):
+            segment = points2[j : j + 2]
             dist1 = perpendicular_distance(segment[0], segment[1], P)
-            _dist2 = (((segment-P)**2).sum(axis=1)**0.5)
+            _dist2 = ((segment - P) ** 2).sum(axis=1) ** 0.5
             dist2 = _dist2.min()
-            dist2_idx =_dist2.argmin()
-            #if closest than current min, and lower than point-point distance
+            dist2_idx = _dist2.argmin()
+            # if closest than current min, and lower than point-point distance
             if dist1 < min_dist and dist1 < dist2:
                 x, y = find_intersection_point(segment[0], segment[1], P)
-                if (x >= segment[:,0].min() and 
-                    x <= segment[:,0].max() and 
-                    y >= segment[:,1].min() and
-                    y <= segment[:,1].max()): #falls within segment
+                if (
+                    x >= segment[:, 0].min()
+                    and x <= segment[:, 0].max()
+                    and y >= segment[:, 1].min()
+                    and y <= segment[:, 1].max()
+                ):  # falls within segment
                     min_dist = dist1
                     min_p1 = P
-                    min_p2 = (x,y)
+                    min_p2 = (x, y)
                     min_i = i
                     min_j = j
                     frac_i = 0
-                    dist_j = ((x-segment[0][0])**2 + (y-segment[0][1])**2)**0.5
-                    frac_j = dist_j / (np.diff(segment, axis=0)**2).sum()**0.5
+                    dist_j = (
+                        (x - segment[0][0]) ** 2 + (y - segment[0][1]) ** 2
+                    ) ** 0.5
+                    frac_j = (
+                        dist_j / (np.diff(segment, axis=0) ** 2).sum() ** 0.5
+                    )
                     updated = True
                 else:
                     updated = False
-            #if point-point distance smaller and smaller than current min
+            # if point-point distance smaller and smaller than current min
             if not updated and dist2 < min_dist:
                 min_dist = dist2
                 min_p1 = P
@@ -976,359 +1122,374 @@ def get_nearest_points(points1, points2):
                 min_j = j
                 frac_i = 0
                 frac_j = dist2_idx
-            #if current min still lowest
+            # if current min still lowest
             else:
-                pass  
-            #reset updater 
-            updated = False  
-    return {'min_dist': min_dist,
-            'p1': min_p1,
-            'p2': min_p2,
-            'idx1': min_i,
-            'idx2': min_j,
-            'frac1': frac_i,
-            'frac2': frac_j}
-            
+                pass
+            # reset updater
+            updated = False
+    return {
+        "min_dist": min_dist,
+        "p1": min_p1,
+        "p2": min_p2,
+        "idx1": min_i,
+        "idx2": min_j,
+        "frac1": frac_i,
+        "frac2": frac_j,
+    }
+
+
 def find_intersection_point(A, B, P):
     x1, y1 = A
     x2, y2 = B
     x0, y0 = P
-    
+
     if x2 == x1:  # Line AB is vertical
         return (x1, y0)
     if y2 == y1:  # Line AB is horizontal
         return (x0, y1)
-    
+
     m_AB = (y2 - y1) / (x2 - x1)
     m_perpendicular = -1 / m_AB
-    
+
     c_AB = y1 - m_AB * x1
     c_perpendicular = y0 - m_perpendicular * x0
-    
+
     x = (c_perpendicular - c_AB) / (m_AB - m_perpendicular)
     y = m_AB * x + c_AB
-    
+
     return (x, y)
+
 
 def perpendicular_distance(A, B, P):
     """
     Calculate the perpendicular distance from a point P to a line defined by points A and B.
-    
+
     Parameters:
     A, B: Points defining the line, given as tuples (x, y).
     P: The point from which the distance is measured, given as a tuple (x, y).
-    
+
     Returns:
     The perpendicular distance from P to the line AB.
     """
     x1, y1 = A
     x2, y2 = B
     x0, y0 = P
-    
+
     # Apply the formula
-    numerator = abs((y2 - y1)*x0 - (x2 - x1)*y0 + x2*y1 - y2*x1)
-    denominator = ((y2 - y1)**2 + (x2 - x1)**2)**0.5
-    
+    numerator = abs((y2 - y1) * x0 - (x2 - x1) * y0 + x2 * y1 - y2 * x1)
+    denominator = ((y2 - y1) ** 2 + (x2 - x1) ** 2) ** 0.5
+
     distance = numerator / denominator
     return distance
 
-def proximities(grouped,
-                bins, 
-                relative,
-                data_cols,
-                meta_cols,
-                i):
-    #update data cols
-    if 'Time' not in data_cols: data_cols += ['Time']
-    if 'X' not in data_cols: data_cols += ['X']
-    if 'Y' not in data_cols: data_cols += ['Y']
-    #if bins
+
+def proximities(grouped, bins, relative, data_cols, meta_cols, i):
+    # update data cols
+    if "Time" not in data_cols:
+        data_cols += ["Time"]
+    if "X" not in data_cols:
+        data_cols += ["X"]
+    if "Y" not in data_cols:
+        data_cols += ["Y"]
+    # if bins
     if bins is not None:
         bins = sorted(set(bins))
-    #get row
+    # get row
     group = grouped.iloc[i]
-    #get files
-    file1 = group['File_0']
-    file2 = group['File_1']
-    #get track combos
-    tids1 = group['ID_0']
-    tids2 = group['ID_1']
-    #read agents
+    # get files
+    file1 = group["File_0"]
+    file2 = group["File_1"]
+    # get track combos
+    tids1 = group["ID_0"]
+    tids2 = group["ID_1"]
+    # read agents
     a1 = read_pkl(file1)
     a2 = read_pkl(file2)
-    #loop over combos
+    # loop over combos
     rows = []
     for k, (tid1, tid2) in enumerate(zip(tids1, tids2)):
-        #get the tracks
+        # get the tracks
         t1 = a1.tracks[tid1]
         t2 = a2.tracks[tid2]
-        #skip 1 pingers
+        # skip 1 pingers
         if len(t1) < 2 or len(t2) < 2:
             continue
-        #filter to common timesteps
-        common = t1['Time'].isin(t2['Time'].values)
-        common_times = t1['Time'].loc[common]
+        # filter to common timesteps
+        common = t1["Time"].isin(t2["Time"].values)
+        common_times = t1["Time"].loc[common]
         common_t1 = t1.loc[common].copy()
-        common_t2 = t2[t2['Time'].isin(common_times.values)].copy()
-        #calculate distances
-        dist = ((common_t1['X'].values - common_t2['X'].values)**2 +
-                (common_t1['Y'].values - common_t2['Y'].values)**2)**0.5
-        #if bins
+        common_t2 = t2[t2["Time"].isin(common_times.values)].copy()
+        # calculate distances
+        dist = (
+            (common_t1["X"].values - common_t2["X"].values) ** 2
+            + (common_t1["Y"].values - common_t2["Y"].values) ** 2
+        ) ** 0.5
+        # if bins
         if bins is not None:
-            #if only 1 ping, cant calculate durations
+            # if only 1 ping, cant calculate durations
             if len(dist) < 2:
                 continue
-            #if more than 1
-            elapsed = (common_times - common_times.iloc[0]).dt.total_seconds().values
+            # if more than 1
+            elapsed = (
+                (common_times - common_times.iloc[0]).dt.total_seconds().values
+            )
             if relative:
-                time_spent = {'Time':common_times.tolist(),
-                                **{b:[0]*len(common_times) for b in bins}}
+                time_spent = {
+                    "Time": common_times.tolist(),
+                    **{b: [0] * len(common_times) for b in bins},
+                }
             else:
-                time_spent = dict(zip(bins, [0]*len(bins)))
+                time_spent = dict(zip(bins, [0] * len(bins)))
             durations = np.diff(elapsed)
-            #loop over bins
+            # loop over bins
             for bin in bins:
-                #loop over distances/durations
-                for j in range(len(dist)-1):
-                    #get segment
+                # loop over distances/durations
+                for j in range(len(dist) - 1):
+                    # get segment
                     d1 = dist[j]
-                    d2 = dist[j+1]
-                    #check if touching or below
+                    d2 = dist[j + 1]
+                    # check if touching or below
                     if d1 <= bin and d2 <= bin:
                         if relative:
                             time_spent[bin][j] += durations[j]
                         else:
                             time_spent[bin] += durations[j]
-                    #check if crossing
-                    elif (d1<bin and d2>bin) or (d1>bin and d2<bin):
+                    # check if crossing
+                    elif (d1 < bin and d2 > bin) or (d1 > bin and d2 < bin):
                         if relative:
-                            frac = (bin-d1)/(d2-d1)
-                            time_spent[bin][j] += durations[j]*frac
+                            frac = (bin - d1) / (d2 - d1)
+                            time_spent[bin][j] += durations[j] * frac
                         else:
-                            frac = (bin-d1)/(d2-d1)
-                            time_spent[bin] += durations[j]*frac
-                    #check if above
+                            frac = (bin - d1) / (d2 - d1)
+                            time_spent[bin] += durations[j] * frac
+                    # check if above
                     else:
                         pass
-        #if relative append the rows
+        # if relative append the rows
         if relative:
             rows.append(time_spent)
-        #if not create non relative rows
+        # if not create non relative rows
         else:
-            #get the minimum distance
+            # get the minimum distance
             idx = np.argmin(dist)
             min_dist = dist[idx]
-            #concat the dataframes
+            # concat the dataframes
             common_t1 = common_t1[data_cols]
             common_t2 = common_t2[data_cols]
-            common_t1.columns = [c+'_0' for c in common_t1.columns]
-            common_t2.columns = [c+'_1' for c in common_t2.columns]
-            row = pd.concat([common_t1.iloc[idx], 
-                            common_t2.iloc[idx]]).to_dict()
-            #add meta data cols
+            common_t1.columns = [c + "_0" for c in common_t1.columns]
+            common_t2.columns = [c + "_1" for c in common_t2.columns]
+            row = pd.concat(
+                [common_t1.iloc[idx], common_t2.iloc[idx]]
+            ).to_dict()
+            # add meta data cols
             for col in meta_cols:
-                row[f'{col}_0'] = a1.agent_meta[col]
-                row[f'{col}_1'] = a2.agent_meta[col] 
-            row['Minimum Distance'] = min_dist
-            row['Agent ID_0'] = a1.agent_meta['Agent ID']
-            row['Agent ID_1'] = a2.agent_meta['Agent ID']
-            row['Track ID_0'] = group['Track ID_0'][k]
-            row['Track ID_1'] = group['Track ID_1'][k]
-            row['Common Timesteps'] = len(common_times)
-            #if bins add time spent in bins
+                row[f"{col}_0"] = a1.agent_meta[col]
+                row[f"{col}_1"] = a2.agent_meta[col]
+            row["Minimum Distance"] = min_dist
+            row["Agent ID_0"] = a1.agent_meta["Agent ID"]
+            row["Agent ID_1"] = a2.agent_meta["Agent ID"]
+            row["Track ID_0"] = group["Track ID_0"][k]
+            row["Track ID_1"] = group["Track ID_1"][k]
+            row["Common Timesteps"] = len(common_times)
+            # if bins add time spent in bins
             if bins is not None:
-                row.update(time_spent)            
-            #append row
+                row.update(time_spent)
+            # append row
             rows.append(row)
     if relative:
-        #its possible no proximities fell inside the bins
+        # its possible no proximities fell inside the bins
         if len(rows) == 0:
-            return pd.DataFrame(columns=['Time']+bins)
-        #if there are rows to concat
+            return pd.DataFrame(columns=["Time"] + bins)
+        # if there are rows to concat
         else:
-            rows = pd.concat([pd.DataFrame(r) for r in rows]).reset_index(drop=True)
-            #this gets the max amount of time spent in each temporal chunk
-            rows = rows.groupby('Time').agg(max).reset_index()
+            rows = pd.concat([pd.DataFrame(r) for r in rows]).reset_index(
+                drop=True
+            )
+            # this gets the max amount of time spent in each temporal chunk
+            rows = rows.groupby("Time").agg(max).reset_index()
     return rows
- 
+
+
 def _get_closest_encounters(t1, t2, time, distance, filter_min):
-    x0, y0 = t1['X'].values, t1['Y'].values
-    x1, y1 = t2['X'].values, t2['Y'].values
-    time1 = np.array(t1['Time'].tolist())
-    time2 = np.array(t2['Time'].tolist())
-    #check where the times overlap
+    x0, y0 = t1["X"].values, t1["Y"].values
+    x1, y1 = t2["X"].values, t2["Y"].values
+    time1 = np.array(t1["Time"].tolist())
+    time2 = np.array(t2["Time"].tolist())
+    # check where the times overlap
     common_start = max([time1[0], time2[0]])
     common_end = min([time1[-1], time2[-1]])
-    #make empty output
-    encounters = [] #[dist, timediff, id0, id1]
-    #if they dont overlap
+    # make empty output
+    encounters = []  # [dist, timediff, id0, id1]
+    # if they dont overlap
     if common_start > common_end:
         return encounters
-    #if they do overlap
+    # if they do overlap
     count, min_idx, min_dist = 0, 0, 999e9
     for i in range(len(x0)):
-        #distance to point from track1
+        # distance to point from track1
         dx = x0[i] - x1
         dy = y0[i] - y1
         dr = dx**2 + dy**2
-        #closest point
+        # closest point
         idx = np.argmin(dr)
-        #dx and dt at this point
-        deltar = dr[idx]**0.5
-        deltat = np.abs(time2[idx]-time1[i]).total_seconds()
-        #if passing thresholds
+        # dx and dt at this point
+        deltar = dr[idx] ** 0.5
+        deltat = np.abs(time2[idx] - time1[i]).total_seconds()
+        # if passing thresholds
         if deltar <= distance and deltat <= time:
-            #if closer than last closest
+            # if closer than last closest
             if deltar <= min_dist:
-                #now the closest
+                # now the closest
                 min_dist = deltar
                 min_idx = count
-            #increase encounter counter
+            # increase encounter counter
             count += 1
-            #append the encounter
-            encounters.append([deltar,
-                               deltat,
-                               i,
-                               idx])
-    #if only minimum
-    if filter_min and len(encounters)>0:
+            # append the encounter
+            encounters.append([deltar, deltat, i, idx])
+    # if only minimum
+    if filter_min and len(encounters) > 0:
         encounters = [encounters[min_idx]]
     return encounters
-   
-def encounters(grouped, 
-               distance, 
-               time, 
-               data_cols, 
-               meta_cols,
-               filter_min,
-               i):
-    #get row
+
+
+def encounters(grouped, distance, time, data_cols, meta_cols, filter_min, i):
+    # get row
     group = grouped.iloc[i]
-    #get files
-    file1 = group['File_0']
-    file2 = group['File_1']
-    #get track combos
-    tids1 = group['ID_0']
-    tids2 = group['ID_1']
-    #read agents
+    # get files
+    file1 = group["File_0"]
+    file2 = group["File_1"]
+    # get track combos
+    tids1 = group["ID_0"]
+    tids2 = group["ID_1"]
+    # read agents
     a1 = read_pkl(file1)
     a2 = read_pkl(file2)
-    #loop over combos
+    # loop over combos
     rows = []
     for j, (tid1, tid2) in enumerate(zip(tids1, tids2)):
         t1 = a1.tracks[tid1]
         t2 = a2.tracks[tid2]
-        #get encounter dist/time
-        encounters = _get_closest_encounters(t1, t2, time, distance, filter_min)
+        # get encounter dist/time
+        encounters = _get_closest_encounters(
+            t1, t2, time, distance, filter_min
+        )
         for encounter in encounters:
             deltar, deltat, idx1, idx2 = encounter
-            #build the dataframe row
-            p1 = Point(t1['X'].iloc[idx1], t1['Y'].iloc[idx1])
-            p2 = Point(t2['X'].iloc[idx2], t2['Y'].iloc[idx2])
+            # build the dataframe row
+            p1 = Point(t1["X"].iloc[idx1], t1["Y"].iloc[idx1])
+            p2 = Point(t2["X"].iloc[idx2], t2["Y"].iloc[idx2])
             center_x = (p1.x + p2.x) / 2
             center_y = (p1.y + p2.y) / 2
             center = Point(center_x, center_y)
             radius = p1.distance(p2) / 2
             circle = center.buffer(radius)
-            row = {'Agent ID_0': a1.agent_meta['Agent ID'],
-                'Track ID_0': group['Track ID_0'][j],
-                'Agent ID_1': a2.agent_meta['Agent ID'],
-                'Track ID_1': group['Track ID_1'][j],
-                'X_0': t1['X'].iloc[idx1],
-                'Y_0': t1['Y'].iloc[idx1],
-                'X_1': t2['X'].iloc[idx2],
-                'Y_1': t2['Y'].iloc[idx2],                    
-                'Time_0': t1['Time'].iloc[idx1],
-                'Time_1': t2['Time'].iloc[idx2],
-                'Minimum Distance': deltar,
-                'Time Difference': deltat,
-                'geometry':circle}
-            #add meta data cols
+            row = {
+                "Agent ID_0": a1.agent_meta["Agent ID"],
+                "Track ID_0": group["Track ID_0"][j],
+                "Agent ID_1": a2.agent_meta["Agent ID"],
+                "Track ID_1": group["Track ID_1"][j],
+                "X_0": t1["X"].iloc[idx1],
+                "Y_0": t1["Y"].iloc[idx1],
+                "X_1": t2["X"].iloc[idx2],
+                "Y_1": t2["Y"].iloc[idx2],
+                "Time_0": t1["Time"].iloc[idx1],
+                "Time_1": t2["Time"].iloc[idx2],
+                "Minimum Distance": deltar,
+                "Time Difference": deltat,
+                "geometry": circle,
+            }
+            # add meta data cols
             for col in meta_cols:
-                row[f'{col}_0'] = a1.agent_meta[col]
-                row[f'{col}_1'] = a2.agent_meta[col] 
-            #add dynamic data cols
+                row[f"{col}_0"] = a1.agent_meta[col]
+                row[f"{col}_1"] = a2.agent_meta[col]
+            # add dynamic data cols
             for col in data_cols:
-                row[f'{col}_0'] = t1[col].iloc[idx1]
-                row[f'{col}_1'] = t2[col].iloc[idx2]    
-            rows.append(row) 
+                row[f"{col}_0"] = t1[col].iloc[idx1]
+                row[f"{col}_1"] = t2[col].iloc[idx2]
+            rows.append(row)
     return rows
 
-def intersections(grouped, 
-                  time, 
-                  data_cols, 
-                  meta_cols,
-                  i):
-    #get row
+
+def intersections(grouped, time, data_cols, meta_cols, i):
+    # get row
     group = grouped.iloc[i]
-    #get files
-    file1 = group['File_0']
-    file2 = group['File_1']
-    #get track combos
-    tids1 = group['ID_0']
-    tids2 = group['ID_1']
-    #read agents
+    # get files
+    file1 = group["File_0"]
+    file2 = group["File_1"]
+    # get track combos
+    tids1 = group["ID_0"]
+    tids2 = group["ID_1"]
+    # read agents
     a1 = read_pkl(file1)
     a2 = read_pkl(file2)
-    #edit data cols
-    if 'Time' not in data_cols: data_cols += ['Time']
-    #loop over combos
+    # edit data cols
+    if "Time" not in data_cols:
+        data_cols += ["Time"]
+    # loop over combos
     rows = []
     for j, (tid1, tid2) in enumerate(zip(tids1, tids2)):
         t1 = a1.tracks[tid1]
         t2 = a2.tracks[tid2]
-        #skip 1 pingers
+        # skip 1 pingers
         if len(t1) < 2 or len(t2) < 2:
             continue
-        #make shapely
-        track1 = LineString(zip(t1['X'].values, 
-                                t1['Y'].values))
-        track2 = LineString(zip(t2['X'].values, 
-                                t2['Y'].values))
-        #make cumulative dists along each track for interpolation
-        cumdist1 = ((t1['X'].diff()**2 + t1['Y'].diff()**2)**0.5).values
+        # make shapely
+        track1 = LineString(zip(t1["X"].values, t1["Y"].values))
+        track2 = LineString(zip(t2["X"].values, t2["Y"].values))
+        # make cumulative dists along each track for interpolation
+        cumdist1 = ((t1["X"].diff() ** 2 + t1["Y"].diff() ** 2) ** 0.5).values
         cumdist1[0] = 0
-        cumdist2 = ((t2['X'].diff()**2 + t2['Y'].diff()**2)**0.5).values
+        cumdist2 = ((t2["X"].diff() ** 2 + t2["Y"].diff() ** 2) ** 0.5).values
         cumdist2[0] = 0
-        #check if it intersects
+        # check if it intersects
         if track1.intersects(track2):
-            #get the intersections
-            cd1, cd2, x, y = find_intersection_points(t1[['X','Y']].values,
-                                                      t2[['X','Y']].values).T
-            #interpolate data to intersections
+            # get the intersections
+            cd1, cd2, x, y = find_intersection_points(
+                t1[["X", "Y"]].values, t2[["X", "Y"]].values
+            ).T
+            # interpolate data to intersections
             new_track1 = interpolate_dynamic_data(t1[data_cols], cd1, cumdist1)
             new_track2 = interpolate_dynamic_data(t2[data_cols], cd2, cumdist2)
-            new_track1['X'] = x
-            new_track1['Y'] = y
-            new_track2['X'] = x
-            new_track2['Y'] = y
-            #reduce to those passing time threshold
-            dt = np.abs(new_track1['Time'] - new_track2['Time']).dt.total_seconds()
+            new_track1["X"] = x
+            new_track1["Y"] = y
+            new_track2["X"] = x
+            new_track2["Y"] = y
+            # reduce to those passing time threshold
+            dt = np.abs(
+                new_track1["Time"] - new_track2["Time"]
+            ).dt.total_seconds()
             mask = dt <= time
-            #if any valid intersections
+            # if any valid intersections
             if sum(mask) > 0:
                 new_track1 = new_track1.loc[mask]
                 new_track2 = new_track2.loc[mask]
-                #combine into 1 dataframe
-                new_track1['Agent ID'] = a1.agent_meta['Agent ID']
-                new_track2['Agent ID'] = a2.agent_meta['Agent ID']
-                new_track1['Track ID'] = group['Track ID_0'][j]
-                new_track2['Track ID'] = group['Track ID_1'][j]
-                new_track1.columns = [f'{col}_0' for col in new_track1.columns]
-                new_track2.columns = [f'{col}_1' for col in new_track2.columns]
+                # combine into 1 dataframe
+                new_track1["Agent ID"] = a1.agent_meta["Agent ID"]
+                new_track2["Agent ID"] = a2.agent_meta["Agent ID"]
+                new_track1["Track ID"] = group["Track ID_0"][j]
+                new_track2["Track ID"] = group["Track ID_1"][j]
+                new_track1.columns = [f"{col}_0" for col in new_track1.columns]
+                new_track2.columns = [f"{col}_1" for col in new_track2.columns]
                 _rows = pd.concat([new_track1, new_track2], axis=1)
-                #add meta data cols
+                # add meta data cols
                 for col in meta_cols:
-                    _rows[f'{col}_0'] = a1.agent_meta[col]
-                    _rows[f'{col}_1'] = a2.agent_meta[col] 
-                #add time difference
-                _rows['Time Difference'] = np.abs(_rows['Time_0'] - _rows['Time_1']).dt.total_seconds().values
-                #add geometry column
-                _rows['geometry'] = _rows[['X_0','Y_0']].apply(lambda xy: Point(*xy), axis=1)
-                rows.extend(_rows.to_dict('records'))
+                    _rows[f"{col}_0"] = a1.agent_meta[col]
+                    _rows[f"{col}_1"] = a2.agent_meta[col]
+                # add time difference
+                _rows["Time Difference"] = (
+                    np.abs(_rows["Time_0"] - _rows["Time_1"])
+                    .dt.total_seconds()
+                    .values
+                )
+                # add geometry column
+                _rows["geometry"] = _rows[["X_0", "Y_0"]].apply(
+                    lambda xy: Point(*xy), axis=1
+                )
+                rows.extend(_rows.to_dict("records"))
             else:
                 pass
     return rows
+
 
 def find_intersection_points(polyline1, polyline2):
     # Initialize an empty list to store intersection points
@@ -1336,11 +1497,11 @@ def find_intersection_points(polyline1, polyline2):
     cumsum0 = 0
     # Iterate through line segments of the first polyline
     for i in range(len(polyline1) - 1):
-        segment1 = polyline1[i:i + 2]
+        segment1 = polyline1[i : i + 2]
         # Iterate through line segments of the second polyline
         cumsum1 = 0
         for j in range(len(polyline2) - 1):
-            segment2 = polyline2[j:j + 2]
+            segment2 = polyline2[j : j + 2]
             # Check for intersection between line segments
             x1, y1 = segment1[0]
             x2, y2 = segment1[1]
@@ -1352,340 +1513,393 @@ def find_intersection_points(polyline1, polyline2):
                 # Calculate intersection point coordinates
                 t = ((x1 - x3) * (y3 - y4) - (y1 - y3) * (x3 - x4)) / det
                 u = -((x1 - x2) * (y1 - y3) - (y1 - y2) * (x1 - x3)) / det
-                #if valid intersection
+                # if valid intersection
                 if 0 <= t <= 1 and 0 <= u <= 1:
                     intersection_x = x1 + t * (x2 - x1)
                     intersection_y = y1 + t * (y2 - y1)
-                    di = cumsum0 + (((x2-x1)**2 + (y2-y1)**2)**0.5 * t)
-                    dj = cumsum1 + (((x4-x3)**2 + (y4-y3)**2)**0.5 * u)
-                    intersection_points.append([di,
-                                                dj,
-                                                intersection_x, 
-                                                intersection_y])
-            #increase the cum distance
-            cumsum1 += ((x4-x3)**2 + (y4-y3)**2)**0.5
-        #increase the cum distance
-        cumsum0 += ((x2-x1)**2 + (y2-y1)**2)**0.5         
+                    di = cumsum0 + (
+                        ((x2 - x1) ** 2 + (y2 - y1) ** 2) ** 0.5 * t
+                    )
+                    dj = cumsum1 + (
+                        ((x4 - x3) ** 2 + (y4 - y3) ** 2) ** 0.5 * u
+                    )
+                    intersection_points.append(
+                        [di, dj, intersection_x, intersection_y]
+                    )
+            # increase the cum distance
+            cumsum1 += ((x4 - x3) ** 2 + (y4 - y3) ** 2) ** 0.5
+        # increase the cum distance
+        cumsum0 += ((x2 - x1) ** 2 + (y2 - y1) ** 2) ** 0.5
     # Convert the list of intersection points to a NumPy array
     return np.array(intersection_points)
+
 
 def is_point_in_bbox(point, bbox):
     (px, py) = point
     (x_min, x_max, y_min, y_max) = bbox
     return x_min <= px <= x_max and y_min <= py <= y_max
 
+
 def det(a, b):
     return a[0] * b[1] - a[1] * b[0]
 
+
 def line_intersection(line1, line2):
-    #calculate determinant
+    # calculate determinant
     xdiff = (line1[0][0] - line1[1][0], line2[0][0] - line2[1][0])
     ydiff = (line1[0][1] - line1[1][1], line2[0][1] - line2[1][1])
     div = det(xdiff, ydiff)
-    #if parallel/coincident
+    # if parallel/coincident
     if div == 0:
-       return None
-    #if intersection
+        return None
+    # if intersection
     d = (det(*line1), det(*line2))
     x = det(d, xdiff) / div
     y = det(d, ydiff) / div
-    #if within bbox of original segments
-    bbox1 = (min(line1[0][0], line1[1][0]), max(line1[0][0], line1[1][0]),
-             min(line1[0][1], line1[1][1]), max(line1[0][1], line1[1][1]))
-    bbox2 = (min(line2[0][0], line2[1][0]), max(line2[0][0], line2[1][0]),
-             min(line2[0][1], line2[1][1]), max(line2[0][1], line2[1][1]))
-    if is_point_in_bbox((x,y), bbox1) and is_point_in_bbox((x,y), bbox2):
+    # if within bbox of original segments
+    bbox1 = (
+        min(line1[0][0], line1[1][0]),
+        max(line1[0][0], line1[1][0]),
+        min(line1[0][1], line1[1][1]),
+        max(line1[0][1], line1[1][1]),
+    )
+    bbox2 = (
+        min(line2[0][0], line2[1][0]),
+        max(line2[0][0], line2[1][0]),
+        min(line2[0][1], line2[1][1]),
+        max(line2[0][1], line2[1][1]),
+    )
+    if is_point_in_bbox((x, y), bbox1) and is_point_in_bbox((x, y), bbox2):
         return x, y
     else:
         return None
 
-def imprint_geometry(polylines, 
-                     out_path, 
-                     args):
-    #split args
+
+def imprint_geometry(polylines, out_path, args):
+    # split args
     pkl_files, tracks = args
-    #read split agent file
+    # read split agent file
     agent = collect_agent_pkls(pkl_files)
-    #reduce to tracks of interest
+    # reduce to tracks of interest
     if len(tracks) > 0:
-        tids = [tid for tid in agent.tracks.keys() 
-                if f'{agent.agent_meta["Agent ID"]}_{tid}' in tracks]
+        tids = [
+            tid
+            for tid in agent.tracks.keys()
+            if f'{agent.agent_meta["Agent ID"]}_{tid}' in tracks
+        ]
     else:
         tids = agent.tracks.keys()
-    #loop over each track, smooth the corners
+    # loop over each track, smooth the corners
     refresh = False
     for tid in tids:
         track = agent.tracks[tid]
         if len(track) == 1:
             continue
-        #if 2 points and same
+        # if 2 points and same
         elif len(track) == 2 and start_equals_end(track):
             continue
         else:
-            xy = track[['X','Y']].values
-            old_time = track['Time']
-            old_times_cumsum = old_time.diff().dt.total_seconds().cumsum().values
-            old_times_cumsum[0] = 0 
-            #loop through shapes
+            xy = track[["X", "Y"]].values
+            old_time = track["Time"]
+            old_times_cumsum = (
+                old_time.diff().dt.total_seconds().cumsum().values
+            )
+            old_times_cumsum[0] = 0
+            # loop through shapes
             new_rows = []
             for line in polylines:
-                #loop over shape segments
-                for i in range(len(line)-1):
-                    shape_segment = line[i], line[i+1]
-                    #loop over track segments
-                    for j in range(len(xy)-1):
-                        track_segment = xy[j], xy[j+1]
-                        #check if intersecting
+                # loop over shape segments
+                for i in range(len(line) - 1):
+                    shape_segment = line[i], line[i + 1]
+                    # loop over track segments
+                    for j in range(len(xy) - 1):
+                        track_segment = xy[j], xy[j + 1]
+                        # check if intersecting
                         # intersection = line_intersection(shape_segment, track_segment)
-                        intersection = find_intersection_points(shape_segment, track_segment)
+                        intersection = find_intersection_points(
+                            shape_segment, track_segment
+                        )
                         # if intersection is not None:
                         if len(intersection) > 0:
                             intersection = intersection[0]
-                            #add the new points into the track
-                            dxi = (intersection[2] - track_segment[0][0])**2
-                            dyi = (intersection[3] - track_segment[0][1])**2
-                            dri = (dxi+dyi)**0.5
-                            dxt = (track_segment[1][0] - track_segment[0][0])**2
-                            dyt = (track_segment[1][1] - track_segment[0][1])**2
-                            drt = (dxt+dyt)**0.5
-                            frac = dri/drt
-                            dtime = (old_time.iloc[j + 1] - old_time.iloc[j]) * frac
+                            # add the new points into the track
+                            dxi = (intersection[2] - track_segment[0][0]) ** 2
+                            dyi = (intersection[3] - track_segment[0][1]) ** 2
+                            dri = (dxi + dyi) ** 0.5
+                            dxt = (
+                                track_segment[1][0] - track_segment[0][0]
+                            ) ** 2
+                            dyt = (
+                                track_segment[1][1] - track_segment[0][1]
+                            ) ** 2
+                            drt = (dxt + dyt) ** 0.5
+                            frac = dri / drt
+                            dtime = (
+                                old_time.iloc[j + 1] - old_time.iloc[j]
+                            ) * frac
                             newtime = old_time.iloc[j] + dtime
-                            new_row = {'Time':newtime, 'X':intersection[2], 'Y':intersection[3]}
+                            new_row = {
+                                "Time": newtime,
+                                "X": intersection[2],
+                                "Y": intersection[3],
+                            }
                             new_rows.append(new_row)
-            #if new points to add   
+            # if new points to add
             if len(new_rows) > 0:
                 refresh = True
                 add_df = pd.DataFrame(new_rows)
-                new_times_cumsum = (add_df['Time'] - track['Time'].iloc[0]).dt.total_seconds().values
-                add_track = interpolate_dynamic_data(track, new_times_cumsum, old_times_cumsum)
-                add_track['X'] = add_df['X'].values
-                add_track['Y'] = add_df['Y'].values
-                new_track = pd.concat([track, add_track]).sort_values(by='Time').drop_duplicates(subset='Time').reset_index(drop=True)          
-                agent.tracks[tid] = new_track                 
+                new_times_cumsum = (
+                    (add_df["Time"] - track["Time"].iloc[0])
+                    .dt.total_seconds()
+                    .values
+                )
+                add_track = interpolate_dynamic_data(
+                    track, new_times_cumsum, old_times_cumsum
+                )
+                add_track["X"] = add_df["X"].values
+                add_track["Y"] = add_df["Y"].values
+                new_track = (
+                    pd.concat([track, add_track])
+                    .sort_values(by="Time")
+                    .drop_duplicates(subset="Time")
+                    .reset_index(drop=True)
+                )
+                agent.tracks[tid] = new_track
     if refresh:
-        #save the agent back
-        out_file = f'{out_path}/{os.path.basename(pkl_files[0])}'
-        save_pkl(out_file, agent)           
+        # save the agent back
+        out_file = f"{out_path}/{os.path.basename(pkl_files[0])}"
+        save_pkl(out_file, agent)
     return
 
-def interpolate_raster(interp, 
-                       name, 
-                       out_path, 
-                       args):
-    #split args
+
+def interpolate_raster(interp, name, out_path, args):
+    # split args
     pkl_files, tracks = args
-    #read split agent file
+    # read split agent file
     agent = collect_agent_pkls(pkl_files)
-    #reduce to tracks of interest
+    # reduce to tracks of interest
     if len(tracks) > 0:
-        tids = [tid for tid in agent.tracks.keys() 
-                if f'{agent.agent_meta["Agent ID"]}_{tid}' in tracks]
+        tids = [
+            tid
+            for tid in agent.tracks.keys()
+            if f'{agent.agent_meta["Agent ID"]}_{tid}' in tracks
+        ]
     else:
         tids = agent.tracks.keys()
-    #loop over each track, interpolate raster
+    # loop over each track, interpolate raster
     for tid in tids:
         track = agent.tracks[tid]
-        xy = track[['X','Y']].values
+        xy = track[["X", "Y"]].values
         result = interp(xy)
         track.loc[:, name] = result
-    #save the agent back
-    out_file = f'{out_path}/{os.path.basename(pkl_files[0])}'
-    save_pkl(out_file, agent)    
-        
-def lateral_distribution(long,
-                         xy, 
-                         dy,
-                         dx, 
-                         meta_cols,
-                         data_cols,
-                         args):
+    # save the agent back
+    out_file = f"{out_path}/{os.path.basename(pkl_files[0])}"
+    save_pkl(out_file, agent)
+
+
+def lateral_distribution(long, xy, dy, dx, meta_cols, data_cols, args):
     rows = []
-    #split args
+    # split args
     pkl_files, tracks = args
-    #read split agent file
+    # read split agent file
     agent = collect_agent_pkls(pkl_files)
-    #reduce to tracks of interest
+    # reduce to tracks of interest
     if len(tracks) > 0:
-        tids = [tid for tid in agent.tracks.keys() 
-                if f'{agent.agent_meta["Agent ID"]}_{tid}' in tracks]
+        tids = [
+            tid
+            for tid in agent.tracks.keys()
+            if f'{agent.agent_meta["Agent ID"]}_{tid}' in tracks
+        ]
     else:
         tids = agent.tracks.keys()
-    #make fake polylines
+    # make fake polylines
     perpx = -dy
     perpy = dx
     polylines = []
     for center in xy:
         fac = 1e9
-        left = center[0]+(perpx*fac) , center[1]+(perpy*fac)
-        right = center[0]-(perpx*fac) , center[1]-(perpy*fac)
+        left = center[0] + (perpx * fac), center[1] + (perpy * fac)
+        right = center[0] - (perpx * fac), center[1] - (perpy * fac)
         segment = np.array([left, right])
         polylines.append(segment)
-    #loop over each track, calculate intersections
+    # loop over each track, calculate intersections
     for tid in tids:
         track = agent.tracks[tid]
-        #skip 1 pingers
+        # skip 1 pingers
         if len(track) < 2:
             continue
-        polyline1 = track[['X','Y']].values
+        polyline1 = track[["X", "Y"]].values
         _pl1 = LineString(polyline1)
-        #loop over polylines
+        # loop over polylines
         intersections = []
         centers = []
-        for polyline2,center,lon in zip(polylines, xy, long):
-            #only if they intersect
+        for polyline2, center, lon in zip(polylines, xy, long):
+            # only if they intersect
             if LineString(polyline2).intersects(_pl1):
-                #get intersection points
-                _i = find_intersection_points(polyline1, polyline2)                
-                #round for geographic & floating pt errors
-                i = np.array(_i).round(8) 
-                #add the longitudinal slice distance
-                add_lon = np.array([lon]*len(i)).reshape(-1,1)
+                # get intersection points
+                _i = find_intersection_points(polyline1, polyline2)
+                # round for geographic & floating pt errors
+                i = np.array(_i).round(8)
+                # add the longitudinal slice distance
+                add_lon = np.array([lon] * len(i)).reshape(-1, 1)
                 i = np.hstack([i, add_lon])
-                #fix lateral distances
-                #get distance from centreline
-                idx = i[:,2] - center[0]
-                idy = i[:,3] - center[1]
-                dr = (idx**2 + idy**2)**0.5
-                #get sign for distance (left or right of centreline)
-                pl2_dist = (np.diff(polyline2, axis=0)**2).sum()**0.5
-                sign = np.where(i[:,1] <= pl2_dist/2, -1, 1)
-                #add signed distance from centreline
-                i[:,1] = dr*sign
-                #append to list
+                # fix lateral distances
+                # get distance from centreline
+                idx = i[:, 2] - center[0]
+                idy = i[:, 3] - center[1]
+                dr = (idx**2 + idy**2) ** 0.5
+                # get sign for distance (left or right of centreline)
+                pl2_dist = (np.diff(polyline2, axis=0) ** 2).sum() ** 0.5
+                sign = np.where(i[:, 1] <= pl2_dist / 2, -1, 1)
+                # add signed distance from centreline
+                i[:, 1] = dr * sign
+                # append to list
                 intersections.extend(i)
-                centers.extend([center]*len(i))
-        #if no intersections
+                centers.extend([center] * len(i))
+        # if no intersections
         if len(intersections) == 0:
             continue
-        #convert to numpy array
+        # convert to numpy array
         intersections = np.array(intersections)
         centers = np.array(centers)
-        #split by direction
-        angle = (np.degrees(np.arctan2(perpx, perpy)) + 180)%360 #TN angle of cross-section from L to R looking down arc
-        xd = np.diff(track['X'])
-        yd = np.diff(track['Y'])
-        dist = np.sqrt(xd ** 2 + yd ** 2)
+        # split by direction
+        angle = (
+            np.degrees(np.arctan2(perpx, perpy)) + 180
+        ) % 360  # TN angle of cross-section from L to R looking down arc
+        xd = np.diff(track["X"])
+        yd = np.diff(track["Y"])
+        dist = np.sqrt(xd**2 + yd**2)
         oldx = np.cumsum(dist)
         oldx = np.hstack([[0], oldx])
-        #prep for interpolation - need coursings for direction checker
-        _data_cols = list(set(data_cols+['Coursing']))
-        new_track = interpolate_dynamic_data(track[_data_cols], 
-                                             intersections[:,0],
-                                             oldx)
-        angle_diffs = (new_track['Coursing'].values - angle)%360
-        direction = np.where(angle_diffs <= 180,  'F', 'T')
-        row = pd.DataFrame({'Longitudinal Distance': intersections[:,4],
-                            'Lateral Distance': intersections[:,1],
-                            'TrackX': intersections[:,2],
-                            'TrackY': intersections[:,3],
-                            'SliceX': centers[:,0],
-                            'SliceY': centers[:,1],
-                            'Direction': direction})
-        #add data cols
+        # prep for interpolation - need coursings for direction checker
+        _data_cols = list(set(data_cols + ["Coursing"]))
+        new_track = interpolate_dynamic_data(
+            track[_data_cols], intersections[:, 0], oldx
+        )
+        angle_diffs = (new_track["Coursing"].values - angle) % 360
+        direction = np.where(angle_diffs <= 180, "F", "T")
+        row = pd.DataFrame(
+            {
+                "Longitudinal Distance": intersections[:, 4],
+                "Lateral Distance": intersections[:, 1],
+                "TrackX": intersections[:, 2],
+                "TrackY": intersections[:, 3],
+                "SliceX": centers[:, 0],
+                "SliceY": centers[:, 1],
+                "Direction": direction,
+            }
+        )
+        # add data cols
         for col in data_cols:
-            row.loc[:,col] = new_track[col]
-        #add meta cols
+            row.loc[:, col] = new_track[col]
+        # add meta cols
         for col in meta_cols:
-            row.loc[:,col] = agent.meta[col]
-        row.loc[:, 'Agent ID'] = agent.meta['Agent ID']
-        row.loc[:, 'Track ID'] = agent.agent_meta['Tracks'][tid]['Track ID']
-        #append row
+            row.loc[:, col] = agent.meta[col]
+        row.loc[:, "Agent ID"] = agent.meta["Agent ID"]
+        row.loc[:, "Track ID"] = agent.agent_meta["Tracks"][tid]["Track ID"]
+        # append row
         rows.append(row)
-    #combine and return
+    # combine and return
     if len(rows) > 0:
         df = pd.concat(rows)
     else:
         df = pd.DataFrame()
     return df
 
-def time_in_polygon(polygon,
-                    edges,
-                    meta_cols,
-                    data_cols,
-                    args):
+
+def time_in_polygon(polygon, edges, meta_cols, data_cols, args):
     rows = []
-    #split args
+    # split args
     pkl_files, tracks = args
-    #read split agent file
+    # read split agent file
     agent = collect_agent_pkls(pkl_files)
-    #reduce to tracks of interest
+    # reduce to tracks of interest
     if len(tracks) > 0:
-        tids = [tid for tid in agent.tracks.keys() 
-                if f'{agent.agent_meta["Agent ID"]}_{tid}' in tracks]
+        tids = [
+            tid
+            for tid in agent.tracks.keys()
+            if f'{agent.agent_meta["Agent ID"]}_{tid}' in tracks
+        ]
     else:
         tids = agent.tracks.keys()
-    #loop over each track, interpolate raster
+    # loop over each track, interpolate raster
     for tid in tids:
         track = agent.tracks[tid]
-        #skip 1 pingers
+        # skip 1 pingers
         if len(track) < 2:
             continue
-        #classify points
-        x = track['X'].values
-        y = track['Y'].values
-        result = np.logical_or(*inpoly2(np.column_stack((x, y)), 
-                                        polygon, 
-                                        edges, ftol=1e-8))  
-        #get segments inside polygon
+        # classify points
+        x = track["X"].values
+        y = track["Y"].values
+        result = np.logical_or(
+            *inpoly2(np.column_stack((x, y)), polygon, edges, ftol=1e-8)
+        )
+        # get segments inside polygon
         result = np.nonzero(result)[0]
         segments = [list(g) for g in consecutive_groups(result)]
         segments = [s for s in segments if len(s) > 1]
-        #if none
+        # if none
         if len(segments) == 0:
             continue
-        #format data cols for necessary
-        if 'X' not in data_cols: data_cols.append('X')
-        if 'Y' not in data_cols: data_cols.append('Y')
-        if 'Time' not in data_cols: data_cols.append('Time')
-        #loop over each segment inside polygon
+        # format data cols for necessary
+        if "X" not in data_cols:
+            data_cols.append("X")
+        if "Y" not in data_cols:
+            data_cols.append("Y")
+        if "Time" not in data_cols:
+            data_cols.append("Time")
+        # loop over each segment inside polygon
         for segment in segments:
-            #get subtrack inside polygon
+            # get subtrack inside polygon
             subtrack = track.iloc[segment][data_cols].copy()
-            #calculate few columns
-            elapsed = (subtrack['Time'].iloc[-1] - subtrack['Time'].iloc[0]).total_seconds()
-            xd = np.diff(subtrack['X'])
-            yd = np.diff(subtrack['Y'])
-            dist = np.sqrt(xd ** 2 + yd ** 2)
+            # calculate few columns
+            elapsed = (
+                subtrack["Time"].iloc[-1] - subtrack["Time"].iloc[0]
+            ).total_seconds()
+            xd = np.diff(subtrack["X"])
+            yd = np.diff(subtrack["Y"])
+            dist = np.sqrt(xd**2 + yd**2)
             distance = sum(dist)
-            #make row
+            # make row
             row = {}
-            #add first and last data cols
+            # add first and last data cols
             first = subtrack.iloc[0].to_dict()
-            row.update({k+'_0': v for k,v in first.items()})
+            row.update({k + "_0": v for k, v in first.items()})
             last = subtrack.iloc[-1].to_dict()
-            row.update({k+'_1': v for k,v in last.items()})
-            #add meta cols
+            row.update({k + "_1": v for k, v in last.items()})
+            # add meta cols
             for col in meta_cols:
                 row[col] = agent.meta[col]
-            row['Agent ID'] = agent.meta['Agent ID']
-            row['Track ID'] = agent.track_meta[tid]['Track ID']
-            #add computed
-            row['Duration'] = elapsed
-            row['Distance Travelled'] = distance
+            row["Agent ID"] = agent.meta["Agent ID"]
+            row["Track ID"] = agent.track_meta[tid]["Track ID"]
+            # add computed
+            row["Duration"] = elapsed
+            row["Distance Travelled"] = distance
             rows.append(row)
     return rows
 
-def generate_flow_map(characteristic_col,
-                      flow_col,
-                      args):
-    #split args
+
+def generate_flow_map(characteristic_col, flow_col, args):
+    # split args
     pkl_files, tracks = args
-    #read split agent file
+    # read split agent file
     agent = collect_agent_pkls(pkl_files)
-    #reduce to tracks of interest
+    # reduce to tracks of interest
     if len(tracks) > 0:
-        tids = [tid for tid in agent.tracks.keys() 
-                if f'{agent.agent_meta["Agent ID"]}_{tid}' in tracks]
+        tids = [
+            tid
+            for tid in agent.tracks.keys()
+            if f'{agent.agent_meta["Agent ID"]}_{tid}' in tracks
+        ]
     else:
         tids = agent.tracks.keys()
-    #loop over each track, route through polygons
+    # loop over each track, route through polygons
     out = []
     for tid in tids:
         track = agent.tracks[tid]
         if characteristic_col is not None:
             track = track[track[characteristic_col]].copy()
-        #route through the polygons
+        # route through the polygons
         route = [track[flow_col].values[0]]
         current = track[flow_col].values[0]
         for node in track[flow_col].values:
@@ -1694,164 +1908,185 @@ def generate_flow_map(characteristic_col,
             else:
                 route.append(node)
                 current = node
-        #if it never left the same polygon
-        if len(route)==1:
+        # if it never left the same polygon
+        if len(route) == 1:
             route.append(node)
-        #split into dictionary and append to rows
-        for i in range(len(route)-1):
+        # split into dictionary and append to rows
+        for i in range(len(route) - 1):
             a = route[i]
-            b = route[i+1]
-            _out = {'Start':a, 
-                    'End':b, 
-                    'Track ID':agent.track_meta[tid]['Track ID']}
+            b = route[i + 1]
+            _out = {
+                "Start": a,
+                "End": b,
+                "Track ID": agent.track_meta[tid]["Track ID"],
+            }
             out.append(_out)
     return out
-            
-def reduce_to_flow_map(characteristic_col,
-                       flow_col,
-                       out_path,
-                       points,
-                       args):
-    #split args
+
+
+def reduce_to_flow_map(characteristic_col, flow_col, out_path, points, args):
+    # split args
     pkl_files, tracks = args
-    #read split agent file
+    # read split agent file
     agent = collect_agent_pkls(pkl_files)
-    #reduce to tracks of interest
+    # reduce to tracks of interest
     if len(tracks) > 0:
-        tids = [tid for tid in agent.tracks.keys() 
-                if f'{agent.agent_meta["Agent ID"]}_{tid}' in tracks]
+        tids = [
+            tid
+            for tid in agent.tracks.keys()
+            if f'{agent.agent_meta["Agent ID"]}_{tid}' in tracks
+        ]
     else:
         tids = agent.tracks.keys()
-    #loop over each track, route through polygons
+    # loop over each track, route through polygons
     for tid in tids:
         track = agent.tracks[tid]
         if characteristic_col is not None:
             track = track[track[characteristic_col]].copy()
-        track.loc[:,'X'] = track[flow_col].apply(lambda x: points.get(x)[0])
-        track.loc[:,'Y'] = track[flow_col].apply(lambda x: points.get(x)[1])
+        track.loc[:, "X"] = track[flow_col].apply(lambda x: points.get(x)[0])
+        track.loc[:, "Y"] = track[flow_col].apply(lambda x: points.get(x)[1])
         agent.tracks[tid] = track.reset_index(drop=True)
-    #save the agent back
-    out_file = f'{out_path}/{os.path.basename(pkl_files[0])}'
-    save_pkl(out_file, agent) 
+    # save the agent back
+    out_file = f"{out_path}/{os.path.basename(pkl_files[0])}"
+    save_pkl(out_file, agent)
 
-def route_through_raster(array,
-                        polygon,
-                        edges,
-                        coords,
-                        end,
-                        out_path,
-                        kwargs,
-                        args):
-    #split args
+
+def route_through_raster(
+    array, polygon, edges, coords, end, out_path, kwargs, args
+):
+    # split args
     pkl_files, tracks = args
-    #read split agent file
+    # read split agent file
     agent = collect_agent_pkls(pkl_files)
-    #reduce to tracks of interest
+    # reduce to tracks of interest
     if len(tracks) > 0:
-        tids = [tid for tid in agent.tracks.keys() 
-                if f'{agent.agent_meta["Agent ID"]}_{tid}' in tracks]
+        tids = [
+            tid
+            for tid in agent.tracks.keys()
+            if f'{agent.agent_meta["Agent ID"]}_{tid}' in tracks
+        ]
     else:
         tids = agent.tracks.keys()
-    #loop over each track, route through polygons
+    # loop over each track, route through polygons
     for tid in tids:
         track = agent.tracks[tid]
-        #skip single point tracks
+        # skip single point tracks
         if len(track) == 1:
             continue
-        #classify points inside polygon
-        x = track['X'].values
-        y = track['Y'].values
-        t = track['Time'].values
-        result = np.logical_or(*inpoly2(np.column_stack((x, y)), 
-                                        polygon, 
-                                        edges,
-                                        ftol=1e-8))
-        #check if doesn't touch
+        # classify points inside polygon
+        x = track["X"].values
+        y = track["Y"].values
+        t = track["Time"].values
+        result = np.logical_or(
+            *inpoly2(np.column_stack((x, y)), polygon, edges, ftol=1e-8)
+        )
+        # check if doesn't touch
         if sum(result) == 0:
             continue
-        #if it does get the groups of ins/outs
+        # if it does get the groups of ins/outs
         split_ids = np.nonzero(np.diff(result))[0] + 1
         groups = np.split(result, split_ids)
         idxs = np.split(range(len(result)), split_ids)
-        #loop over pairs of groups
+        # loop over pairs of groups
         new_tracks = []
-        for i in range(len(groups)-1):
+        for i in range(len(groups) - 1):
             g1 = groups[i]
-            g2 = groups[i+1]
-            #if starts inside
-            if g1[0]: 
+            g2 = groups[i + 1]
+            # if starts inside
+            if g1[0]:
                 if i == 0:
-                    #first point
-                    p0 = x[idxs[i][0]], y[idxs[i][0]]  
+                    # first point
+                    p0 = x[idxs[i][0]], y[idxs[i][0]]
                     t0 = t[idxs[i][0]]
                 else:
-                    #last point
-                    p0 = x[idxs[i][-1]], y[idxs[i][-1]]  
+                    # last point
+                    p0 = x[idxs[i][-1]], y[idxs[i][-1]]
                     t0 = t[idxs[i][-1]]
                 before_idx = []
-            #if starts outside
+            # if starts outside
             else:
-                #crossing point into raster
+                # crossing point into raster
                 _p01 = x[idxs[i][-1]], y[idxs[i][-1]]
-                _p02 = x[idxs[i+1][0]], y[idxs[i+1][0]]
-                p0 =  find_intersection_points(np.array([_p01, _p02]), polygon)[:, 2:][0]
-                dtotal = ((_p01[0] - _p02[0])**2 + (_p01[1] - _p02[1])**2)**0.5
-                dint = ((_p01[0] - p0[0])**2 + (_p01[1] - p0[1])**2)**0.5
-                frac = dint/dtotal
+                _p02 = x[idxs[i + 1][0]], y[idxs[i + 1][0]]
+                p0 = find_intersection_points(np.array([_p01, _p02]), polygon)[
+                    :, 2:
+                ][0]
+                dtotal = (
+                    (_p01[0] - _p02[0]) ** 2 + (_p01[1] - _p02[1]) ** 2
+                ) ** 0.5
+                dint = ((_p01[0] - p0[0]) ** 2 + (_p01[1] - p0[1]) ** 2) ** 0.5
+                frac = dint / dtotal
                 before_idx = idxs[i]
-                dt = (t[idxs[i+1][0]] - t[idxs[i][-1]]) * frac #frac along point segment
+                dt = (
+                    t[idxs[i + 1][0]] - t[idxs[i][-1]]
+                ) * frac  # frac along point segment
                 t0 = t[idxs[i][-1]] + dt
-            #if ends inside
+            # if ends inside
             if g2[0]:
-                #if override
+                # if override
                 if end is not None:
                     p1 = end
-                    t1 = t[idxs[i+1][-1]]
-                #last point
+                    t1 = t[idxs[i + 1][-1]]
+                # last point
                 else:
-                    p1 = x[idxs[i+1][-1]], y[idxs[i+1][-1]]
-                    t1 = t[idxs[i+1][-1]]
+                    p1 = x[idxs[i + 1][-1]], y[idxs[i + 1][-1]]
+                    t1 = t[idxs[i + 1][-1]]
                 after_idx = []
-            #if ends outside
+            # if ends outside
             else:
-                #crossing point out of raster
+                # crossing point out of raster
                 _p11 = x[idxs[i][-1]], y[idxs[i][-1]]
-                _p12 = x[idxs[i+1][0]], y[idxs[i+1][0]]
-                p1 = find_intersection_points(np.array([_p11, _p12]), polygon)[:, 2:][0]
-                dtotal = ((_p11[0] - _p12[0])**2 + (_p11[1] - _p12[1])**2)**0.5
-                dint = ((_p11[0] - p1[0])**2 + (_p11[1] - p1[1])**2)**0.5
-                frac = dint/dtotal
-                after_idx = idxs[i+1]
-                dt = (t[idxs[i+1][0]] - t[idxs[i][-1]]) * frac #frac along point segment
+                _p12 = x[idxs[i + 1][0]], y[idxs[i + 1][0]]
+                p1 = find_intersection_points(np.array([_p11, _p12]), polygon)[
+                    :, 2:
+                ][0]
+                dtotal = (
+                    (_p11[0] - _p12[0]) ** 2 + (_p11[1] - _p12[1]) ** 2
+                ) ** 0.5
+                dint = ((_p11[0] - p1[0]) ** 2 + (_p11[1] - p1[1]) ** 2) ** 0.5
+                frac = dint / dtotal
+                after_idx = idxs[i + 1]
+                dt = (
+                    t[idxs[i + 1][0]] - t[idxs[i][-1]]
+                ) * frac  # frac along point segment
                 t1 = t[idxs[i][-1]] + dt
-            #get i,j coords of each point
+            # get i,j coords of each point
             startij = NN_idx2(p0, coords)
             endij = NN_idx2(p1, coords)
-            #get routed indices
+            # get routed indices
             routed_ij = route_through_array(array, startij, endij, **kwargs)[0]
             rows, cols = zip(*routed_ij)
             new_x = coords[rows, cols, 0]
             new_y = coords[rows, cols, 1]
-            #get new coordinates
+            # get new coordinates
             before = track.iloc[before_idx]
             try:
-                routed = pd.DataFrame({'X': new_x, 
-                                    'Y':new_y,
-                                    'Time':[t0, *[pd.NaT]*(len(new_x)-2), t1]})
+                routed = pd.DataFrame(
+                    {
+                        "X": new_x,
+                        "Y": new_y,
+                        "Time": [t0, *[pd.NaT] * (len(new_x) - 2), t1],
+                    }
+                )
             except:
-                print(agent.agent_meta['Agent ID'], tid)
+                print(agent.agent_meta["Agent ID"], tid)
             after = track.iloc[after_idx]
             new_tracks.append(pd.concat([before, routed, after]))
-        #reconstruct track
+        # reconstruct track
         new_track = pd.concat(new_tracks).reset_index(drop=True)
-        #fill the time column
-        if isinstance(new_track.iloc[-1]['Time'], type(pd.NaT)):
-            new_track.iat[-1, new_track.columns.get_loc('Time')] = track.iloc[-1]['Time']
-        new_track['Time'] = new_track['Time'].interpolate(method='linear')
-        #reset track
-        agent.tracks[tid] = new_track.drop_duplicates(subset='Time').reset_index(drop=True)
-    #save the agent back
-    out_file = f'{out_path}/{os.path.basename(pkl_files[0])}'
-    save_pkl(out_file, agent) 
+        # fill the time column
+        if isinstance(new_track.iloc[-1]["Time"], type(pd.NaT)):
+            new_track.iat[-1, new_track.columns.get_loc("Time")] = track.iloc[
+                -1
+            ]["Time"]
+        new_track["Time"] = new_track["Time"].interpolate(method="linear")
+        # reset track
+        agent.tracks[tid] = new_track.drop_duplicates(
+            subset="Time"
+        ).reset_index(drop=True)
+    # save the agent back
+    out_file = f"{out_path}/{os.path.basename(pkl_files[0])}"
+    save_pkl(out_file, agent)
+
 
 ################################################################################

--- a/trackio/io.py
+++ b/trackio/io.py
@@ -1,197 +1,202 @@
-from .utils import collect_agent_pkls
-from .Agent import gen_track_meta
+import os
 
 import numpy as np
-from shapely.geometry import LineString, MultiLineString
 import rasterio as rio
-from rasterio.transform import Affine
-import os
 from osgeo import gdal, gdalconst
 from pyproj import CRS
+from rasterio.transform import Affine
+from shapely.geometry import LineString, MultiLineString
+
+from .Agent import gen_track_meta
+from .utils import collect_agent_pkls
+
 
 def to_track_gdf(agent, track, tid, code):
-    #if just returning whole track
+    # if just returning whole track
     if code is None:
-        linestring = LineString([[x, y] for x,y in zip(track['X'], track['Y'])])
-    #if returning split multilinestring of only coded parts
+        linestring = LineString(
+            [[x, y] for x, y in zip(track["X"], track["Y"])]
+        )
+    # if returning split multilinestring of only coded parts
     else:
-        mask = track[f'Code{code}']
+        mask = track[f"Code{code}"]
         diffs = np.diff(mask)
-        #if all points meet codemask criteria
+        # if all points meet codemask criteria
         if np.sum(diffs) == 0 and np.all(mask):
-            #return whole track
-            linestring = LineString([[x, y] for x,y in zip(track['X'], track['Y'])])
-        #if only some points meet codemask critiera, split
+            # return whole track
+            linestring = LineString(
+                [[x, y] for x, y in zip(track["X"], track["Y"])]
+            )
+        # if only some points meet codemask critiera, split
         else:
-            split_ids = np.nonzero(diffs)[0]+1
-            xs = np.split(track['X'], split_ids)
-            ys = np.split(track['Y'], split_ids)
+            split_ids = np.nonzero(diffs)[0] + 1
+            xs = np.split(track["X"], split_ids)
+            ys = np.split(track["Y"], split_ids)
             masks = np.split(mask, split_ids)
-            #skip if all only have 1 ping
-            if np.all([len(mask)==1 for mask in masks]):
+            # skip if all only have 1 ping
+            if np.all([len(mask) == 1 for mask in masks]):
                 return
-            #make detached linestrings/multilinestrings
+            # make detached linestrings/multilinestrings
             else:
                 linestring = []
-                #loop through chunks
+                # loop through chunks
                 for i in range(len(xs)):
-                    #if code is True and more than 1 point
+                    # if code is True and more than 1 point
                     if np.all(masks[i]) and len(masks[i]) > 1:
-                        _linestring = LineString([[x, y] for x,y in zip(xs[i], ys[i])])
+                        _linestring = LineString(
+                            [[x, y] for x, y in zip(xs[i], ys[i])]
+                        )
                         linestring.append(_linestring)
                     else:
                         pass
-                #somehow still empty?
+                # somehow still empty?
                 if len(linestring) > 0:
                     linestring = MultiLineString(linestring)
                 else:
                     return
-    #make the row for the geodataframe
+    # make the row for the geodataframe
     meta = agent.agent_meta.copy()
-    #delete this entry
-    del meta['Tracks']
+    # delete this entry
+    del meta["Tracks"]
     meta.update(**agent.track_meta[tid].copy())
-    meta['geometry'] = linestring
+    meta["geometry"] = linestring
     return [meta]
 
-def to_segment_gdf(agent,
-                   track,
-                   tid,
-                   code,
-                   method):
-    #get track id
-    track_id = agent.track_meta[tid]['Track ID']
-    #initialize rows
+
+def to_segment_gdf(agent, track, tid, code, method):
+    # get track id
+    track_id = agent.track_meta[tid]["Track ID"]
+    # initialize rows
     rows = []
-    #loop over track points
-    for i in range(len(track)-1):
-        subtrack = track.iloc[i:i+2]
-        #check if it meets the codemask
+    # loop over track points
+    for i in range(len(track) - 1):
+        subtrack = track.iloc[i : i + 2]
+        # check if it meets the codemask
         if code is not None:
-            #if neither part of segment passes
-            if not subtrack[f'Code{code}'].any():
-                continue        
-        #make segment linestring
-        linestring = LineString(subtrack[['X','Y']])
-        #make segment id
-        segment_id = f'{track_id}_S{i}'
-        #make meta
+            # if neither part of segment passes
+            if not subtrack[f"Code{code}"].any():
+                continue
+        # make segment linestring
+        linestring = LineString(subtrack[["X", "Y"]])
+        # make segment id
+        segment_id = f"{track_id}_S{i}"
+        # make meta
         meta = agent.agent_meta.copy()
-        #delete this entry
-        del meta['Tracks']
-        #add track meta
+        # delete this entry
+        del meta["Tracks"]
+        # add track meta
         tmeta = gen_track_meta(subtrack)
-        if method in ['forward', 'backward']:
-            if method == 'forward':
+        if method in ["forward", "backward"]:
+            if method == "forward":
                 index = 0
             else:
                 index = 1
             for col in subtrack.columns:
-                if col not in ['Time','X','Y']:
+                if col not in ["Time", "X", "Y"]:
                     tmeta[col] = subtrack.iloc[index][col]
         else:
             for_tmeta = subtrack.mean().to_frame().T.astype(subtrack.dtypes)
             for col in for_tmeta.columns:
-                if col not in ['Time','X','Y']:
+                if col not in ["Time", "X", "Y"]:
                     tmeta[col] = for_tmeta.iloc[0][col]
-        #see if still passing the code requirement after interpolation method
+        # see if still passing the code requirement after interpolation method
         if code is not None:
-            if not tmeta[f'Code{code}']:
+            if not tmeta[f"Code{code}"]:
                 continue
-        #finish the meta
+        # finish the meta
         meta.update(**tmeta)
-        #add geometry and segment ID
-        meta['Segment ID'] = segment_id
-        meta['geometry'] = linestring
-        rows.append(meta)        
+        # add geometry and segment ID
+        meta["Segment ID"] = segment_id
+        meta["geometry"] = linestring
+        rows.append(meta)
     return rows
 
-def to_gdf(code,
-           segments,
-           method,
-           args):
+
+def to_gdf(code, segments, method, args):
     rows = []
-    #split the agrs
+    # split the agrs
     pkl_files, tracks = args
-    #read split agent file
+    # read split agent file
     agent = collect_agent_pkls(pkl_files)
-    #reduce to tracks of interest
+    # reduce to tracks of interest
     if len(tracks) > 0:
-        tids = [tid for tid in agent.tracks.keys() 
-                if f'{agent.agent_meta["Agent ID"]}_{tid}' in tracks]
+        tids = [
+            tid
+            for tid in agent.tracks.keys()
+            if f'{agent.agent_meta["Agent ID"]}_{tid}' in tracks
+        ]
     else:
         tids = agent.tracks.keys()
-    #loop over each track
+    # loop over each track
     for tid in tids:
         track = agent.tracks[tid]
-        #skip tracks with only 1 point
+        # skip tracks with only 1 point
         if len(track) < 2:
             continue
-        #skip if doesnt have the code
+        # skip if doesnt have the code
         if code is not None:
-            #if 1 or less points
-            if len(track[track[f'Code{code}']]) < 2:
+            # if 1 or less points
+            if len(track[track[f"Code{code}"]]) < 2:
                 continue
         if segments:
             meta = to_segment_gdf(agent, track, tid, code, method)
         else:
             meta = to_track_gdf(agent, track, tid, code)
-        #if gdf row(s) returned
+        # if gdf row(s) returned
         if meta is not None:
             rows.extend(meta)
     return rows
 
-def to_df(code,
-          args):
+
+def to_df(code, args):
     dfs = []
-    #split the agrs
+    # split the agrs
     pkl_files, tracks = args
-    #read split agent file
+    # read split agent file
     agent = collect_agent_pkls(pkl_files)
-    #reduce to tracks of interest
+    # reduce to tracks of interest
     if len(tracks) > 0:
-        tids = [tid for tid in agent.tracks.keys() 
-                if f'{agent.agent_meta["Agent ID"]}_{tid}' in tracks]
+        tids = [
+            tid
+            for tid in agent.tracks.keys()
+            if f'{agent.agent_meta["Agent ID"]}_{tid}' in tracks
+        ]
     else:
         tids = agent.tracks.keys()
-    #loop over each track
+    # loop over each track
     for tid in tids:
         track = agent.tracks[tid]
-        track_id = agent.track_meta[tid]['Track ID']
-        #get rid of codes
+        track_id = agent.track_meta[tid]["Track ID"]
+        # get rid of codes
         if code is not None:
-            track = track[track[f'Code{code}']].copy() #copy? wtf? why
-        #if nothing left
+            track = track[track[f"Code{code}"]].copy()  # copy? wtf? why
+        # if nothing left
         if len(track) < 1:
             continue
-        #make point ids
-        track.index = [f'{track_id}_P{i}' for i in range(len(track))]
-        #add track id
-        track.loc[:, 'Track ID'] = track_id
-        #add agent meta
+        # make point ids
+        track.index = [f"{track_id}_P{i}" for i in range(len(track))]
+        # add track id
+        track.loc[:, "Track ID"] = track_id
+        # add agent meta
         meta = agent.meta
-        for key,val in meta.items():
+        for key, val in meta.items():
             track.loc[:, key] = val
-        #append to list
+        # append to list
         dfs.append(track)
     return dfs
 
-def create_blank_raster(out_file, 
-                        crs, 
-                        grid={'x0':0, 
-                              'y0':0,
-                              'nx':1,
-                              'ny':1, 
-                              'dx':1, 
-                              'dy':1}):
+
+def create_blank_raster(
+    out_file, crs, grid={"x0": 0, "y0": 0, "nx": 1, "ny": 1, "dx": 1, "dy": 1}
+):
     """
     Creates a blank raster file with specified dimensions, resolution, and coordinate reference system (CRS).
 
     Here, CRS can be a EPSG code, WKT string, proj4 string, pyproj.CRS object, etc.
 
-    This function generates an empty (blank) raster file, which can serve as a template for rasterizing tracks. 
-    
-    The raster dimensions, resolution, and spatial reference are defined by the user. The resulting raster will 
+    This function generates an empty (blank) raster file, which can serve as a template for rasterizing tracks.
+
+    The raster dimensions, resolution, and spatial reference are defined by the user. The resulting raster will
     have all its pixel values set to 0 by default.
 
     Args:
@@ -203,25 +208,29 @@ def create_blank_raster(out_file,
     Returns:
         None
     """
-    assert out_file.lower().endswith('.tif'), 'out_file must be a .tif file'
-    profile = {'count': 1,
-               'crs': CRS(crs),
-               'driver': 'GTiff',
-               'dtype': 'float32',
-               'height': grid['ny'],
-               'interleave': 'band',
-               'nodata': None,
-               'tiled': False,
-               'transform': Affine(grid['dx'], 0.0, grid['x0'],
-                                   0.0, grid['dy'], grid['y0']),
-               'width': grid['nx']}
-    data = np.zeros((grid['ny'], grid['nx']))
-    with rio.open(out_file, 'w', **profile) as f:
+    assert out_file.lower().endswith(".tif"), "out_file must be a .tif file"
+    profile = {
+        "count": 1,
+        "crs": CRS(crs),
+        "driver": "GTiff",
+        "dtype": "float32",
+        "height": grid["ny"],
+        "interleave": "band",
+        "nodata": None,
+        "tiled": False,
+        "transform": Affine(
+            grid["dx"], 0.0, grid["x0"], 0.0, grid["dy"], grid["y0"]
+        ),
+        "width": grid["nx"],
+    }
+    data = np.zeros((grid["ny"], grid["nx"]))
+    with rio.open(out_file, "w", **profile) as f:
         f.write(data, 1)
-    print(f'Raster created and saved to {out_file}!')
+    print(f"Raster created and saved to {out_file}!")
     return
 
-# def rasterize_gdf(gdf, out_file, attr=None, 
+
+# def rasterize_gdf(gdf, out_file, attr=None,
 #                   grid={'x0':0, 'y0':0, 'nx':1, 'ny':1, 'dx':1, 'dy':1}):
 #     out_file = os.path.abspath(out_file)
 #     if attr is not None:
@@ -245,10 +254,8 @@ def create_blank_raster(out_file,
 #     output = None
 #     print(f'Raster written to {out_file}')
 
-def rasterize(shp_file, 
-              ras_file, 
-              out_file, 
-              attribute=None):
+
+def rasterize(shp_file, ras_file, out_file, attribute=None):
     """
     Rasterizes a shapefile/gpkg/geojson onto an existing raster file saving the result to a new raster file.
 
@@ -272,37 +279,44 @@ def rasterize(shp_file,
     Returns:
         None
     """
-    #make abspath
+    # make abspath
     out_file = os.path.abspath(out_file)
     ras_file = os.path.abspath(ras_file)
-    shp_file = os.path.abspath(shp_file)    
-    #make gdal raster inputs
+    shp_file = os.path.abspath(shp_file)
+    # make gdal raster inputs
     ras = gdal.Open(ras_file, gdalconst.GA_ReadOnly)
     geo_transform = ras.GetGeoTransform()
     x_res = ras.RasterXSize
     y_res = ras.RasterYSize
-    output = gdal.GetDriverByName('GTiff').Create(out_file, x_res, y_res, 1, gdal.GDT_Float32)
+    output = gdal.GetDriverByName("GTiff").Create(
+        out_file, x_res, y_res, 1, gdal.GDT_Float32
+    )
     output.SetGeoTransform(geo_transform)
     output.SetProjection(ras.GetSpatialRef().ExportToWkt())
-    output.GetRasterBand(1).SetNoDataValue(0)  
-    #rasterize
+    output.GetRasterBand(1).SetNoDataValue(0)
+    # rasterize
     if attribute is None:
-        #rasterize counts
-        gdal.Rasterize(output, 
-                       shp_file, 
-                       options=gdal.RasterizeOptions(add=True, 
-                                                     burnValues=1,
-                                                     allTouched=True)) 
-        print(f'Track Counts written to {out_file}')
-    else:  
-        #rasterize attribute
-        gdal.Rasterize(output, 
-                       shp_file, 
-                       options=gdal.RasterizeOptions(add=True, 
-                                                     attribute=attribute,
-                                                     allTouched=True))
-        print(f'Track {attribute} written to {out_file}')
-    #flush the output
+        # rasterize counts
+        gdal.Rasterize(
+            output,
+            shp_file,
+            options=gdal.RasterizeOptions(
+                add=True, burnValues=1, allTouched=True
+            ),
+        )
+        print(f"Track Counts written to {out_file}")
+    else:
+        # rasterize attribute
+        gdal.Rasterize(
+            output,
+            shp_file,
+            options=gdal.RasterizeOptions(
+                add=True, attribute=attribute, allTouched=True
+            ),
+        )
+        print(f"Track {attribute} written to {out_file}")
+    # flush the output
     output = None
-    
+
+
 ################################################################################

--- a/trackio/maps.py
+++ b/trackio/maps.py
@@ -1,34 +1,49 @@
 ################################################################################
 
-from .utils import (read_pkl, 
-                    save_pkl, 
-                    collect_agent_pkls, 
-                    flatten,
-                    flatten_dict_unique)
-
 import json
-import os
-import pandas as pd
-import numpy as np
 import multiprocessing as mp
-from tqdm import tqdm; GREEN = "\033[92m"; ENDC = "\033[0m" #for tqdm bar
+import os
 from functools import partial
+
+import numpy as np
+import pandas as pd
+from tqdm import tqdm
+
+from .utils import (
+    collect_agent_pkls,
+    flatten,
+    flatten_dict_unique,
+    read_pkl,
+    save_pkl,
+)
+
+GREEN = "\033[92m"
+ENDC = "\033[0m"  # for tqdm bar
 
 ################################################################################
 
-#these are hardcoded
-code_mapper_file = f'{os.path.dirname(__file__)}/supporting/ais_code_mapper.csv'
-aiscodes_file = f'{os.path.dirname(__file__)}/supporting/AIS_Codes.csv'
-column_mapper_file = f'{os.path.dirname(__file__)}/supporting/column_mapper.csv'
-status_mapper_file = f'{os.path.dirname(__file__)}/supporting/ais_status_mapper.csv'
+# these are hardcoded
+code_mapper_file = (
+    f"{os.path.dirname(__file__)}/supporting/ais_code_mapper.csv"
+)
+aiscodes_file = f"{os.path.dirname(__file__)}/supporting/AIS_Codes.csv"
+column_mapper_file = (
+    f"{os.path.dirname(__file__)}/supporting/column_mapper.csv"
+)
+status_mapper_file = (
+    f"{os.path.dirname(__file__)}/supporting/ais_status_mapper.csv"
+)
+
 
 def read_json(json_file):
-    with open(json_file, 'r') as f:
+    with open(json_file, "r") as f:
         return json.load(f)
 
+
 def save_json(json_file, obj):
-    with open(json_file, 'w') as f:
+    with open(json_file, "w") as f:
         json.dump(obj, f, indent=2)
+
 
 def std_mapper(meta):
     mapper = {}
@@ -39,95 +54,121 @@ def std_mapper(meta):
             mapper[v.lower()] = k
             mapper[v.upper()] = k
             mapper[v.title()] = k
-            mapper[v.replace('_',' ')] = k
-            mapper[v.replace('-',' ')] = k
-            mapper[v.replace('-','_')] = k
-            mapper[v.replace('_','-')] = k  
-        mapper[k] = k 
+            mapper[v.replace("_", " ")] = k
+            mapper[v.replace("-", " ")] = k
+            mapper[v.replace("-", "_")] = k
+            mapper[v.replace("_", "-")] = k
+        mapper[k] = k
     return mapper
+
 
 class mappers:
     def __init__(self):
         pass
+
     @property
     def ais(self):
-        out = {'Status': std_mapper(pd.read_csv(status_mapper_file).set_index('Mapped')['Raw'].apply(eval).to_dict()),
-               'AISCode': std_mapper(pd.read_csv(code_mapper_file).set_index('Mapped')['Raw'].apply(eval).to_dict()),
-               'Type': pd.read_csv(aiscodes_file, usecols=['code','type']).set_index('code')['type'].to_dict(),
-               'TypeStandard': pd.read_csv(aiscodes_file, usecols=['code','typestandard']).set_index('code')['typestandard'].to_dict()}
-        out['Status']['__file__'] = status_mapper_file
-        out['AISCode']['__file__'] =  code_mapper_file
+        out = {
+            "Status": std_mapper(
+                pd.read_csv(status_mapper_file)
+                .set_index("Mapped")["Raw"]
+                .apply(eval)
+                .to_dict()
+            ),
+            "AISCode": std_mapper(
+                pd.read_csv(code_mapper_file)
+                .set_index("Mapped")["Raw"]
+                .apply(eval)
+                .to_dict()
+            ),
+            "Type": pd.read_csv(aiscodes_file, usecols=["code", "type"])
+            .set_index("code")["type"]
+            .to_dict(),
+            "TypeStandard": pd.read_csv(
+                aiscodes_file, usecols=["code", "typestandard"]
+            )
+            .set_index("code")["typestandard"]
+            .to_dict(),
+        }
+        out["Status"]["__file__"] = status_mapper_file
+        out["AISCode"]["__file__"] = code_mapper_file
         return out
+
     @property
     def columns(self):
-        out = std_mapper(pd.read_csv(column_mapper_file).set_index('Mapped')['Raw'].apply(eval).to_dict())
-        out['__file__'] = column_mapper_file
+        out = std_mapper(
+            pd.read_csv(column_mapper_file)
+            .set_index("Mapped")["Raw"]
+            .apply(eval)
+            .to_dict()
+        )
+        out["__file__"] = column_mapper_file
         return out
+
     def update(self, old, new):
         """
-        Updates the mapper file stored on disk. Use this when you want to add or update an entry 
+        Updates the mapper file stored on disk. Use this when you want to add or update an entry
         so it get's auto-detected next time.
 
         Args:
             old: Original dictionary mapper.
             new: Updated dictionary mapper.
-            
+
         Returns:
             None
         """
-        #check if it can be updated
-        msg = 'This mapper is not meant to be dynamically updated'
-        assert '__file__' in old.keys(), msg
-        #get old
-        old_file = old['__file__']
+        # check if it can be updated
+        msg = "This mapper is not meant to be dynamically updated"
+        assert "__file__" in old.keys(), msg
+        # get old
+        old_file = old["__file__"]
         old = pd.read_csv(old_file)
-        old['Raw'] = old['Raw'].apply(eval)
-        old.set_index('Mapped', inplace=True)
-        #update 
-        #drop any nan incase
+        old["Raw"] = old["Raw"].apply(eval)
+        old.set_index("Mapped", inplace=True)
+        # update
+        # drop any nan incase
         for k in new.copy().keys():
             if not isinstance(k, str) and np.isnan(k):
                 new.pop(k)
-            elif new[k] == '':
+            elif new[k] == "":
                 new.pop(k)
             else:
                 pass
         raw = new.keys()
         mapped = new.values()
-        add = pd.DataFrame({'Raw':raw,'Mapped':mapped})
-        add.set_index('Mapped', inplace=True)
+        add = pd.DataFrame({"Raw": raw, "Mapped": mapped})
+        add.set_index("Mapped", inplace=True)
         for i in range(len(add)):
             row = add.iloc[i]
             mapped = row.name
-            raw = row['Raw']
-            if raw not in old.loc[mapped,'Raw']:
-                old.loc[mapped,'Raw'].append(row['Raw'])
-        #rewrite
+            raw = row["Raw"]
+            if raw not in old.loc[mapped, "Raw"]:
+                old.loc[mapped, "Raw"].append(row["Raw"])
+        # rewrite
         old.reset_index(inplace=True)
         old.to_csv(old_file, index=False)
         return print(f"Updated mapper in {old_file}")
 
-#initialize for __init__
+
+# initialize for __init__
 _mappers = mappers()
 
-def drop_agent_meta(inp,
-                    out_path,
-                    file):
-    #read agent
+
+def drop_agent_meta(inp, out_path, file):
+    # read agent
     agent = read_pkl(file)
-    #loop over meta cols
+    # loop over meta cols
     for i in inp:
         agent.meta.pop(i, None)
-    #write it back out
-    out_file = f'{out_path}/{os.path.basename(file)}'
+    # write it back out
+    out_file = f"{out_path}/{os.path.basename(file)}"
     save_pkl(out_file, agent)
 
-def drop_agent_data(inp,
-                    out_path,
-                    file):
-    #read agent
+
+def drop_agent_data(inp, out_path, file):
+    # read agent
     agent = read_pkl(file)
-    #if split file
+    # if split file
     if len(agent.tracks) > 0:
         for tid in agent.tracks.keys():
             for i in inp:
@@ -139,162 +180,156 @@ def drop_agent_data(inp,
             a = agent._data
             if i in a.columns:
                 a.pop(i)
-    #write it back out
-    out_file = f'{out_path}/{os.path.basename(file)}'
+    # write it back out
+    out_file = f"{out_path}/{os.path.basename(file)}"
     save_pkl(out_file, agent)
-    
-def map_agent_meta(inp, 
-                   out, 
-                   mapper, 
-                   out_path,
-                   drop, 
-                   fill,
-                   file):
-    #read agent
+
+
+def map_agent_meta(inp, out, mapper, out_path, drop, fill, file):
+    # read agent
     agent = read_pkl(file)
-    #loop over mappers
-    for i,o in zip(inp,out):
+    # loop over mappers
+    for i, o in zip(inp, out):
         m = mapper[i]
-        #add new meta value
+        # add new meta value
         if i in agent.meta.keys():
             agent.meta[o] = m.get(agent.meta[i], fill)
             if drop:
                 agent.meta.pop(i)
         else:
             agent.meta[o] = fill
-    #write it back out
-    out_file = f'{out_path}/{os.path.basename(file)}'
+    # write it back out
+    out_file = f"{out_path}/{os.path.basename(file)}"
     save_pkl(out_file, agent)
-    
-def map_agent_data(inp,
-                   out,
-                   mapper,
-                   out_path,
-                   drop,
-                   fill,
-                   args):
-    #split the args
+
+
+def map_agent_data(inp, out, mapper, out_path, drop, fill, args):
+    # split the args
     pkl_files, tracks = args
     ntracks = len(tracks)
-    #if all data
+    # if all data
     if ntracks == 0:
-        #loop over files
+        # loop over files
         for pkl_file in pkl_files:
-            #read file
+            # read file
             agent = read_pkl(pkl_file)
-            #if a split file
+            # if a split file
             if len(agent.tracks) > 0:
-                #loop over tracks
+                # loop over tracks
                 for tid in agent.tracks.keys():
-                    #get dataframe
+                    # get dataframe
                     tdf = agent.tracks[tid]
-                    #loop over mappers
-                    for i,o in zip(inp,out):
+                    # loop over mappers
+                    for i, o in zip(inp, out):
                         m = mapper[i]
-                        #if input column not missing
+                        # if input column not missing
                         if i in tdf.columns:
-                            tdf[o] = tdf[i].apply(lambda x: m.get(x,fill)) 
+                            tdf[o] = tdf[i].apply(lambda x: m.get(x, fill))
                             if drop:
                                 tdf.pop(i)
-                        #if it is missing
+                        # if it is missing
                         else:
-                            tdf[o] = [fill]*len(tdf)
-                    #replace track
+                            tdf[o] = [fill] * len(tdf)
+                    # replace track
                     agent.tracks[tid] = tdf
-            #unsplit file
+            # unsplit file
             else:
-                for i,o in zip(inp,out):
+                for i, o in zip(inp, out):
                     m = mapper[i]
                     if i in agent._data.columns:
-                        agent._data[o] = agent._data[i].apply(lambda x: m.get(x,fill)) 
+                        agent._data[o] = agent._data[i].apply(
+                            lambda x: m.get(x, fill)
+                        )
                         if drop:
                             agent._data.pop(i)
                     else:
-                        agent._data[o] = [fill]*len(agent._data)
-            #write it back out
-            out_file = f'{out_path}/{os.path.basename(pkl_file)}'
+                        agent._data[o] = [fill] * len(agent._data)
+            # write it back out
+            out_file = f"{out_path}/{os.path.basename(pkl_file)}"
             save_pkl(out_file, agent)
     else:
-        #loop over files
+        # loop over files
         for pkl_file in pkl_files:
             refresh = False
-            #read file
+            # read file
             agent = read_pkl(pkl_file)
-            #loop over tracks
+            # loop over tracks
             for tid in agent.tracks.keys():
                 if f"{agent.meta['Agent ID']}_{tid}" in tracks:
                     refresh = True
                     tdf = agent.tracks[tid]
-                    for i,o in zip(inp,out):
+                    for i, o in zip(inp, out):
                         m = mapper[i]
                         if i in tdf.columns:
-                            tdf[o] = tdf[i].apply(lambda x: m.get(x,fill)) 
+                            tdf[o] = tdf[i].apply(lambda x: m.get(x, fill))
                             if drop:
                                 tdf.pop(i)
                         else:
-                            tdf[o] = [fill]*len(tdf)
+                            tdf[o] = [fill] * len(tdf)
                     agent.tracks[tid] = tdf
             if refresh:
-                #write it back out
-                out_file = f'{out_path}/{os.path.basename(pkl_file)}'
+                # write it back out
+                out_file = f"{out_path}/{os.path.basename(pkl_file)}"
                 save_pkl(out_file, agent)
-                
-def map_agent_data_to_codes(inp,
-                            mapper,
-                            out_path,
-                            drop,
-                            fill,
-                            args):
-    #split the args
+
+
+def map_agent_data_to_codes(inp, mapper, out_path, drop, fill, args):
+    # split the args
     pkl_files, tracks = args
     ntracks = len(tracks)
-    #if all data
+    # if all data
     if ntracks == 0:
-        #loop over files
+        # loop over files
         for pkl_file in pkl_files:
-            #read file
+            # read file
             agent = read_pkl(pkl_file)
-            #if a split file
+            # if a split file
             if len(agent.tracks) > 0:
                 for tid in agent.tracks.keys():
                     tdf = agent.tracks[tid]
                     for i in inp:
                         m = mapper[i]
                         if i in tdf.columns:
-                            mapped = tdf[i].apply(lambda x: m.get(x,fill)).values #fill if missing 
+                            mapped = (
+                                tdf[i].apply(lambda x: m.get(x, fill)).values
+                            )  # fill if missing
                             for val in set(m.values()):
-                                tdf[f'Code{val}'] = (mapped == val)
+                                tdf[f"Code{val}"] = mapped == val
                             if drop:
                                 tdf.pop(i)
                         else:
-                            mapped = np.array([fill]*len(tdf))
+                            mapped = np.array([fill] * len(tdf))
                             for val in set(m.values()):
-                                tdf[f'Code{val}'] = (mapped == val)
+                                tdf[f"Code{val}"] = mapped == val
                     agent.tracks[tid] = tdf
-            #unsplit file
+            # unsplit file
             else:
                 for i in inp:
                     m = mapper[i]
                     if i in agent._data.columns:
-                        mapped = agent._data[i].apply(lambda x: m.get(x,fill)).values #-1 if missing 
+                        mapped = (
+                            agent._data[i]
+                            .apply(lambda x: m.get(x, fill))
+                            .values
+                        )  # -1 if missing
                         for val in set(m.values()):
-                            agent._data[f'Code{val}'] = (mapped == val)
+                            agent._data[f"Code{val}"] = mapped == val
                         if drop:
                             agent._data.pop(i)
                     else:
-                        mapped = np.array([fill]*len(tdf))
+                        mapped = np.array([fill] * len(tdf))
                         for val in set(m.values()):
-                            agent._data[f'Code{val}'] = (mapped == val)
-            #write it back out
-            out_file = f'{out_path}/{os.path.basename(pkl_file)}'
+                            agent._data[f"Code{val}"] = mapped == val
+            # write it back out
+            out_file = f"{out_path}/{os.path.basename(pkl_file)}"
             save_pkl(out_file, agent)
     else:
-        #loop over files
+        # loop over files
         for pkl_file in pkl_files:
             refresh = False
-            #read file
+            # read file
             agent = read_pkl(pkl_file)
-            #loop over tracks
+            # loop over tracks
             for tid in agent.tracks.keys():
                 if f"{agent.meta['Agent ID']}_{tid}" in tracks:
                     refresh = True
@@ -302,39 +337,43 @@ def map_agent_data_to_codes(inp,
                     for i in inp:
                         m = mapper[i]
                         if i in tdf.columns:
-                            mapped = tdf[i].apply(lambda x: m.get(x,fill)).values #fill if missing 
+                            mapped = (
+                                tdf[i].apply(lambda x: m.get(x, fill)).values
+                            )  # fill if missing
                             for val in m.values():
-                                tdf[f'Code{val}'] = (mapped == val)
+                                tdf[f"Code{val}"] = mapped == val
                             if drop:
                                 tdf.pop(i)
                         else:
-                            mapped = np.array([fill]*len(tdf))
+                            mapped = np.array([fill] * len(tdf))
                             for val in m.values():
-                                tdf[f'Code{val}'] = (mapped == val)
+                                tdf[f"Code{val}"] = mapped == val
                     agent.tracks[tid] = tdf
             if refresh:
-                #write it back out
-                out_file = f'{out_path}/{os.path.basename(pkl_file)}'
+                # write it back out
+                out_file = f"{out_path}/{os.path.basename(pkl_file)}"
                 save_pkl(out_file, agent)
-                  
+
+
 def make_meta_mapper(inp, pkl_file):
-    #out dict
-    out = {i:[] for i in inp}
-    #read the file
+    # out dict
+    out = {i: [] for i in inp}
+    # read the file
     agent = read_pkl(pkl_file)
     for i in inp:
         out[i].append(agent.meta[i])
     return out
-                            
+
+
 def make_data_mapper(inp, args):
-    #split the args
+    # split the args
     pkl_files, tracks = args
     ntracks = len(tracks)
-    #out dict
-    out = {i:[] for i in inp}
-    #if all data
+    # out dict
+    out = {i: [] for i in inp}
+    # if all data
     if ntracks == 0:
-        #read the file
+        # read the file
         agent = collect_agent_pkls(pkl_files)
         full_dat = pd.concat([agent.data, *agent.append_data])
         for i in inp:
@@ -343,12 +382,12 @@ def make_data_mapper(inp, args):
         for pkl_file in pkl_files:
             agent = read_pkl(pkl_file)
             for tid in agent.tracks.keys():
-                #if not one of the tracks to process
+                # if not one of the tracks to process
                 if f"{agent.meta['Agent ID']}_{tid}" in tracks:
-                    #get unique values for each data col
+                    # get unique values for each data col
                     for i in inp:
                         out[i].extend(np.unique(agent.tracks[tid][i]).tolist())
-    #reduce to unique only
+    # reduce to unique only
     for i in out.keys():
         out[i] = np.unique(out[i]).tolist()
     return out
@@ -358,7 +397,9 @@ def _make_col_mapper(file: str, sep: str):
     return pd.read_csv(file, nrows=0, sep=sep).columns.tolist()
 
 
-def make_col_mapper(files: list[str], ncores: int = 1, fill_mapper: dict = {}, sep: str = ",") -> dict:
+def make_col_mapper(
+    files: list[str], ncores: int = 1, fill_mapper: dict = {}, sep: str = ","
+) -> dict:
     """
     Creates a dictionary mapper of all unique columns in a list of files.
 
@@ -375,7 +416,13 @@ def make_col_mapper(files: list[str], ncores: int = 1, fill_mapper: dict = {}, s
     with mp.Pool(ncores) as pool:
         func = partial(_make_col_mapper, sep=sep)
         cols = pool.map(
-            func, tqdm(files, total=len(files), desc=GREEN + "Making column mapper" + ENDC, colour="GREEN")
+            func,
+            tqdm(
+                files,
+                total=len(files),
+                desc=GREEN + "Making column mapper" + ENDC,
+                colour="GREEN",
+            ),
         )
     # flatten and get unique only
     cols = np.unique(flatten(cols))
@@ -384,12 +431,13 @@ def make_col_mapper(files: list[str], ncores: int = 1, fill_mapper: dict = {}, s
     # return mapper
     return dict(zip(cols, vals))
 
+
 def map_columns(chunk, col_mapper):
-    #make new column names
+    # make new column names
     new_cols = []
     for col in chunk.columns:
         new_cols.append(col_mapper.get(col, col))
-    #set new column names
+    # set new column names
     chunk.columns = new_cols
     return chunk
 
@@ -398,28 +446,37 @@ def _make_raw_data_mapper(data_cols, col_mapper, sep, file):
     # get the columns
     cols = pd.read_csv(file, nrows=0, sep=sep).columns.tolist()
     mapped_cols = [col_mapper.get(c, c) for c in cols]
-    #see which columns/attributes exist and to read
+    # see which columns/attributes exist and to read
     read_icols = []
     read_attrs = []
     for attr in data_cols:
         if attr in mapped_cols:
             read_icols.append(mapped_cols.index(attr))
             read_attrs.append(attr)
-    #read the file only once
+    # read the file only once
     usecols = [cols[i] for i in read_icols]
-    df = pd.read_csv(file, usecols=usecols, sep=sep)[usecols]  # to reorder them
+    df = pd.read_csv(file, usecols=usecols, sep=sep)[
+        usecols
+    ]  # to reorder them
     df.columns = read_attrs
-    #format to unique dict
+    # format to unique dict
     out = {}
     for col in df.columns:
         out[col] = df[col].unique().tolist()
-    #return
+    # return
     return out
 
 
-def make_raw_data_mapper(files, col_mapper=_mappers.columns, data_cols=[], fill_mapper={}, ncores=4, sep=","):
+def make_raw_data_mapper(
+    files,
+    col_mapper=_mappers.columns,
+    data_cols=[],
+    fill_mapper={},
+    ncores=4,
+    sep=",",
+):
     """
-    Creates a dictionary mapper of possible raw data values in a list of files, for a 
+    Creates a dictionary mapper of possible raw data values in a list of files, for a
     list of columns in the raw files.
 
     Args:
@@ -433,22 +490,29 @@ def make_raw_data_mapper(files, col_mapper=_mappers.columns, data_cols=[], fill_
     Returns:
         dict: Raw data mapping dictionary.
     """
-    #if only one column
-    assert len(data_cols)>0, 'Length of data_cols must be > 0'
-    #get list of unique values for each attribute/column
+    # if only one column
+    assert len(data_cols) > 0, "Length of data_cols must be > 0"
+    # get list of unique values for each attribute/column
     with mp.Pool(ncores) as pool:
         func = partial(_make_raw_data_mapper, data_cols, col_mapper, sep)
-        _out = pool.map(func, tqdm(files, total=len(files), desc=GREEN + "QCing data columns" + ENDC, colour="GREEN"))
+        _out = pool.map(
+            func,
+            tqdm(
+                files,
+                total=len(files),
+                desc=GREEN + "QCing data columns" + ENDC,
+                colour="GREEN",
+            ),
+        )
     # reformat into key:list dict
     out = flatten_dict_unique(_out)
-    #convert list to raw:mapped dict
+    # convert list to raw:mapped dict
     for key in out.keys():
         fill = fill_mapper.get(key, {})
         raw = out[key]
-        mapped = [fill.get(v,None) for v in raw]
-        out[key] = dict(zip(raw,mapped))
+        mapped = [fill.get(v, None) for v in raw]
+        out[key] = dict(zip(raw, mapped))
     if len(out.keys()) == 1:
         return out[key]
     else:
         return out
-        

--- a/trackio/process.py
+++ b/trackio/process.py
@@ -1,23 +1,28 @@
 ################################################################################
 
-from . import utils
-from .maps import map_columns
-from .maps import _mappers as mappers
-from .Agent import Agent
-
-import pandas as pd
-import pickle as pkl
+import multiprocessing as mp
 import os
+import pickle as pkl
+from functools import partial
+
 import numpy as np
+import pandas as pd
 from inpoly import inpoly2
 from shapely.geometry import Polygon
-from functools import partial
-import multiprocessing as mp
-from tqdm import tqdm; GREEN = "\033[92m"; ENDC = "\033[0m" #for tqdm bar
+from tqdm import tqdm
+
+from . import utils
+from .Agent import Agent
+from .maps import _mappers as mappers
+from .maps import map_columns
+
+GREEN = "\033[92m"
+ENDC = "\033[0m"  # for tqdm bar
 
 ################################################################################
 
-must_cols = ['Time','X','Y']
+must_cols = ["Time", "X", "Y"]
+
 
 def group_points(
     groupby,
@@ -33,225 +38,235 @@ def group_points(
 ):
     # if it's a file
     if isinstance(raw_file, str):
-        if (not raw_file.lower().endswith('.csv')):
+        if not raw_file.lower().endswith(".csv"):
             print(f'Raw file "{raw_file}" is not a csv, skipping...')
             return
         # get the reader, if csv then chunk for big ones, feather can't be chunked
-        reader = pd.read_csv(raw_file, chunksize=chunksize, on_bad_lines="warn", sep=sep)
+        reader = pd.read_csv(
+            raw_file, chunksize=chunksize, on_bad_lines="warn", sep=sep
+        )
         # split raw ais pings to pkls by groupby
         for chunk in reader:
-            _group_points(chunk, 
-                          groupby,
-                          out_path,
-                          col_mapper,
-                          meta_cols,
-                          data_cols,
-                          data_mappers,
-                          prefix)
-    #if raw dataframe
+            _group_points(
+                chunk,
+                groupby,
+                out_path,
+                col_mapper,
+                meta_cols,
+                data_cols,
+                data_mappers,
+                prefix,
+            )
+    # if raw dataframe
     if isinstance(raw_file, pd.DataFrame):
-        _group_points(raw_file,
-                      groupby,
-                      out_path,
-                      col_mapper,
-                      meta_cols,
-                      data_cols,
-                      data_mappers,
-                      prefix)
+        _group_points(
+            raw_file,
+            groupby,
+            out_path,
+            col_mapper,
+            meta_cols,
+            data_cols,
+            data_mappers,
+            prefix,
+        )
 
-def _group_points(chunk, 
-                  groupby, 
-                  out_path, 
-                  col_mapper,
-                  meta_cols,
-                  data_cols,
-                  data_mappers,
-                  prefix):
-    #get process ID
-    pid = mp.current_process().name.replace('SpawnPoolWorker-', 'processor')
-    #format the data columns
+
+def _group_points(
+    chunk,
+    groupby,
+    out_path,
+    col_mapper,
+    meta_cols,
+    data_cols,
+    data_mappers,
+    prefix,
+):
+    # get process ID
+    pid = mp.current_process().name.replace("SpawnPoolWorker-", "processor")
+    # format the data columns
     dat = map_columns(chunk, col_mapper)
-    #get a list of all columns necessary to keep
+    # get a list of all columns necessary to keep
     if isinstance(groupby, str):
         all_cols = np.unique(meta_cols + data_cols + [groupby]).tolist()
-        check_cols = must_cols+[groupby]
+        check_cols = must_cols + [groupby]
     else:
         all_cols = meta_cols.copy() + data_cols.copy()
         all_cols.extend(groupby)
         all_cols = np.unique(all_cols).tolist()
         check_cols = must_cols.copy()
         check_cols.extend(groupby)
-    #get columns vailable from the lists passed
+    # get columns vailable from the lists passed
     available_cols = [c for c in dat.columns if c in all_cols]
-    #make sure groupby, time, x, y all in there
-    msg = f'Data files/dataframe must at minimum contain {must_cols} and {groupby} columns'
+    # make sure groupby, time, x, y all in there
+    msg = f"Data files/dataframe must at minimum contain {must_cols} and {groupby} columns"
     assert all([col in available_cols for col in check_cols]), msg
-    #filter the data
+    # filter the data
     dat = dat.filter(available_cols)
-    #convert all strings to datetime
-    dat['Time'] = pd.to_datetime(dat['Time'])
-    #delete missing/nan critical columns
+    # convert all strings to datetime
+    dat["Time"] = pd.to_datetime(dat["Time"])
+    # delete missing/nan critical columns
     dat = dat.dropna(subset=must_cols)
-    #format any data columns that have mappers
+    # format any data columns that have mappers
     for col in dat.columns:
         if col in data_cols:
             if col in data_mappers.keys():
                 mapper = data_mappers[col]
-                dat[col] = dat[col].apply(lambda x: mapper.get(x,x))
-    #group by groupby column, append all entries to giant lists - this is faster than .groupby??
+                dat[col] = dat[col].apply(lambda x: mapper.get(x, x))
+    # group by groupby column, append all entries to giant lists - this is faster than .groupby??
     dat = dat.sort_values(by=groupby)
-    dat['id'] = range(len(dat))
-    ids = dat[[groupby,'id']].groupby(groupby)['id'].agg(list).values
+    dat["id"] = range(len(dat))
+    ids = dat[[groupby, "id"]].groupby(groupby)["id"].agg(list).values
     grouped = [dat.iloc[i] for i in ids]
-    #loop through groups, append each to appropriate binary file
+    # loop through groups, append each to appropriate binary file
     for i in range(len(grouped)):
-        #get the group of pings
+        # get the group of pings
         group = grouped[i]
-        #get the groupby and agent id
+        # get the groupby and agent id
         aid = f"{prefix}" + str(group[groupby].iloc[0])
-        #make meta and data
+        # make meta and data
         meta = group[meta_cols].iloc[0].to_dict()
-        data = pd.DataFrame(group[data_cols].to_dict(orient='list'))
+        data = pd.DataFrame(group[data_cols].to_dict(orient="list"))
         agent = Agent(aid, meta, data)
-        #append the pickle
+        # append the pickle
         outfile = f"{out_path}/{aid}_{pid}.points"
         utils.append_pkl(outfile, agent)
 
-def split_tracks_spatiotemporal(time, 
-                                distance, 
-                                out_path,
-                                remove,
-                                method,
-                                args):
-    #split the args
+
+def split_tracks_spatiotemporal(
+    time, distance, out_path, remove, method, args
+):
+    # split the args
     pkl_files, tracks = args
-    #get agent with collected unsplit points
+    # get agent with collected unsplit points
     agent = utils.collect_agent_pkls(pkl_files)
-    #split the points using threshold
-    agent = agent.split_tracks_spatiotemporal(time=time, 
-                                              distance=distance,
-                                              tracks=tracks,
-                                              method=method)
-    #now rewrite the pickles
+    # split the points using threshold
+    agent = agent.split_tracks_spatiotemporal(
+        time=time, distance=distance, tracks=tracks, method=method
+    )
+    # now rewrite the pickles
     new_name = f'{agent.meta["Agent ID"]}.tracks'
     # out_file = pkl_files[0].replace(os.path.basename(pkl_file), new_name)
     out_file = os.path.abspath(os.path.join(out_path, new_name))
-    #add file to meta
-    agent.agent_meta['File'] = out_file
+    # add file to meta
+    agent.agent_meta["File"] = out_file
     # rewrite pickles
     with open(out_file, "wb") as f:
         pkl.dump(agent, f)
-    #if removing unsplit data after splitting
+    # if removing unsplit data after splitting
     if remove:
         for pkl_file in pkl_files:
-            #incase it rewrote the same file
+            # incase it rewrote the same file
             if os.path.abspath(pkl_file) != out_file:
                 os.remove(pkl_file)
 
-def split_tracks_by_data(data_col,
-                         out_path,
-                         remove,
-                         args):
-    #split the args
+
+def split_tracks_by_data(data_col, out_path, remove, args):
+    # split the args
     pkl_files, tracks = args
-    #get agent with collected unsplit points
+    # get agent with collected unsplit points
     agent = utils.collect_agent_pkls(pkl_files)
-    #split the points using threshold
-    agent = agent.split_tracks_by_data(data_col,
-                                       tracks=tracks)
-    #now rewrite the pickles
+    # split the points using threshold
+    agent = agent.split_tracks_by_data(data_col, tracks=tracks)
+    # now rewrite the pickles
     new_name = f'{agent.meta["Agent ID"]}.tracks'
     # out_file = pkl_files[0].replace(os.path.basename(pkl_file), new_name)
     out_file = os.path.abspath(os.path.join(out_path, new_name))
-    #add file to meta
-    agent.agent_meta['File'] = out_file
+    # add file to meta
+    agent.agent_meta["File"] = out_file
     # rewrite pickles
     with open(out_file, "wb") as f:
         pkl.dump(agent, f)
-    #if removing unsplit data after splitting
+    # if removing unsplit data after splitting
     if remove:
         for pkl_file in pkl_files:
-            #incase it rewrote the same file
+            # incase it rewrote the same file
             if os.path.abspath(pkl_file) != out_file:
                 os.remove(pkl_file)
 
-def split_tracks_kmeans(n_clusters, 
-                        feature_cols, 
-                        out_path,
-                        return_error,
-                        remove,
-                        optimal_method,
-                        kwargs,
-                        args):
-    #split the args
+
+def split_tracks_kmeans(
+    n_clusters,
+    feature_cols,
+    out_path,
+    return_error,
+    remove,
+    optimal_method,
+    kwargs,
+    args,
+):
+    # split the args
     pkl_files, tracks = args
-    #get agent with collected unsplit points
+    # get agent with collected unsplit points
     agent = utils.collect_agent_pkls(pkl_files)
-    #split the tracks using kmeans clustering
-    agent = agent.split_tracks_kmeans(n_clusters=n_clusters,
-                                      feature_cols=feature_cols,
-                                      return_inertia=return_error,
-                                      tracks=tracks,
-                                      optimal_method=optimal_method,
-                                      **kwargs)
-    #split if necessary
+    # split the tracks using kmeans clustering
+    agent = agent.split_tracks_kmeans(
+        n_clusters=n_clusters,
+        feature_cols=feature_cols,
+        return_inertia=return_error,
+        tracks=tracks,
+        optimal_method=optimal_method,
+        **kwargs,
+    )
+    # split if necessary
     if return_error:
         agent, error = agent
-    #now rewrite the pickles
+    # now rewrite the pickles
     new_name = f'{agent.meta["Agent ID"]}.tracks'
     # out_file = pkl_files[0].replace(os.path.basename(pkl_file), new_name)
     out_file = os.path.abspath(os.path.join(out_path, new_name))
-    #add file to meta
-    agent.agent_meta['File'] = out_file
+    # add file to meta
+    agent.agent_meta["File"] = out_file
     # rewrite pickles
     utils.save_pkl(out_file, agent)
-    #if removing unsplit data after splitting
+    # if removing unsplit data after splitting
     if remove:
         for pkl_file in pkl_files:
-            #incase it rewrote the same file
+            # incase it rewrote the same file
             if os.path.abspath(pkl_file) != out_file:
                 os.remove(pkl_file)
-    #if returning error
+    # if returning error
     if return_error:
-        return error  
+        return error
 
-def split_tracks_dbscan(feature_cols, 
-                        out_path, 
-                        remove, 
-                        eps, 
-                        min_samples,
-                        kwargs,
-                        args):
-    #split the args
+
+def split_tracks_dbscan(
+    feature_cols, out_path, remove, eps, min_samples, kwargs, args
+):
+    # split the args
     pkl_files, tracks = args
-    #get agent with collected unsplit points
+    # get agent with collected unsplit points
     agent = utils.collect_agent_pkls(pkl_files)
-    #split the tracks using kmeans clustering
-    agent = agent.split_tracks_dbscan(feature_cols=feature_cols,
-                                      tracks=tracks,
-                                      eps=eps,
-                                      min_samples=min_samples,
-                                      **kwargs)
-    #now rewrite the pickles
+    # split the tracks using kmeans clustering
+    agent = agent.split_tracks_dbscan(
+        feature_cols=feature_cols,
+        tracks=tracks,
+        eps=eps,
+        min_samples=min_samples,
+        **kwargs,
+    )
+    # now rewrite the pickles
     new_name = f'{agent.meta["Agent ID"]}.tracks'
     out_file = os.path.abspath(os.path.join(out_path, new_name))
-    #add file to meta
-    agent.agent_meta['File'] = out_file
+    # add file to meta
+    agent.agent_meta["File"] = out_file
     # rewrite pickles
     utils.save_pkl(out_file, agent)
-    #if removing unsplit data after splitting
+    # if removing unsplit data after splitting
     if remove:
         for pkl_file in pkl_files:
-            #incase it rewrote the same file
+            # incase it rewrote the same file
             if os.path.abspath(pkl_file) != out_file:
                 os.remove(pkl_file)
 
-def clip_to_box(files, 
-                bbox, 
-                col_mapper=mappers.columns,
-                out_path='.', 
-                ncores=1, 
-                pattern='_clipped'):
+
+def clip_to_box(
+    files,
+    bbox,
+    col_mapper=mappers.columns,
+    out_path=".",
+    ncores=1,
+    pattern="_clipped",
+):
     """
     Clips data in a list of csv files to a user defined box, writes to clipped csv files.
 
@@ -270,30 +285,37 @@ def clip_to_box(files,
     """
     if isinstance(bbox, (Polygon)):
         bbox = bbox.bounds
-    elif len(bbox)==4 and isinstance(bbox, (tuple,list,np.ndarray)):
+    elif len(bbox) == 4 and isinstance(bbox, (tuple, list, np.ndarray)):
         x0 = bbox[0]
         x1 = bbox[2]
         y0 = bbox[1]
         y1 = bbox[3]
-        msg = 'bbox must be shapely Polygon, box or list of (xmin, ymin, xmax, ymax)'
-        assert x1>x0 and y1>y0, msg
+        msg = "bbox must be shapely Polygon, box or list of (xmin, ymin, xmax, ymax)"
+        assert x1 > x0 and y1 > y0, msg
     else:
-        raise Exception('bbox must be shapely Polygon, box or list of (xmin, ymin, xmax, ymax)')
-    clip_to_shape(files, 
-                  bbox, 
-                  out_path=out_path, 
-                  ncores=ncores, 
-                  poly=False, 
-                  pattern=pattern,
-                  col_mapper=col_mapper)
+        raise Exception(
+            "bbox must be shapely Polygon, box or list of (xmin, ymin, xmax, ymax)"
+        )
+    clip_to_shape(
+        files,
+        bbox,
+        out_path=out_path,
+        ncores=ncores,
+        poly=False,
+        pattern=pattern,
+        col_mapper=col_mapper,
+    )
 
-def clip_to_polygon(files, 
-                    poly, 
-                    col_mapper=mappers.columns,
-                    out_path='.', 
-                    ncores=1, 
-                    sep=',',
-                    pattern='_clipped'):
+
+def clip_to_polygon(
+    files,
+    poly,
+    col_mapper=mappers.columns,
+    out_path=".",
+    ncores=1,
+    sep=",",
+    pattern="_clipped",
+):
     """
     Clips data in a list of csv files to a user defined polygon, writes to clipped csv files.
 
@@ -313,49 +335,67 @@ def clip_to_polygon(files,
     """
     if isinstance(poly, Polygon):
         poly = np.array(poly.exterior.xy).T
-        edges = [(i,i+1) for i in range(len(poly)-1)]
+        edges = [(i, i + 1) for i in range(len(poly) - 1)]
     elif isinstance(poly, np.ndarray):
-        edges = [(i,i+1) for i in range(len(poly)-1)]
+        edges = [(i, i + 1) for i in range(len(poly) - 1)]
         pass
     else:
-        raise Exception('Polygon must be shapely polygon or 2D numpy array of polygon exterior pts')
+        raise Exception(
+            "Polygon must be shapely polygon or 2D numpy array of polygon exterior pts"
+        )
     poly = (poly, edges)
-    clip_to_shape(files, 
-                  poly, 
-                  out_path=out_path, 
-                  ncores=ncores, 
-                  poly=True, 
-                  pattern=pattern,
-                  col_mapper=col_mapper,
-                  sep=sep)
+    clip_to_shape(
+        files,
+        poly,
+        out_path=out_path,
+        ncores=ncores,
+        poly=True,
+        pattern=pattern,
+        col_mapper=col_mapper,
+        sep=sep,
+    )
 
-def clip_to_shape(files, 
-                  extent, 
-                  out_path='.', 
-                  ncores=1, 
-                  poly=True, 
-                  col_mapper=mappers.columns,
-                  sep=',',
-                  pattern='_clipped'):   
+
+def clip_to_shape(
+    files,
+    extent,
+    out_path=".",
+    ncores=1,
+    poly=True,
+    col_mapper=mappers.columns,
+    sep=",",
+    pattern="_clipped",
+):
     if ncores > len(files):
         ncores = len(files)
     else:
         pass
-    keep_files = [f for f in files if f.lower().endswith('.csv')]
+    keep_files = [f for f in files if f.lower().endswith(".csv")]
     missed_files = [f for f in files if f not in keep_files]
     for missed_file in missed_files:
         print(f'Raw file "{missed_file}" is not a csv, skipping...')
     out_files = []
     for raw_file in keep_files:
-        out_files.append(os.path.join(out_path, os.path.basename(raw_file).replace(".csv", f"{pattern}.csv")))
+        out_files.append(
+            os.path.join(
+                out_path,
+                os.path.basename(raw_file).replace(".csv", f"{pattern}.csv"),
+            )
+        )
     clip_func = partial(_clip_to_shape, extent, poly, col_mapper, sep)
     args = list(zip(out_files, files))
     with mp.Pool(ncores) as pool:
         args = list(zip(out_files, files))
-        pool.starmap(clip_func, tqdm(args, 
-                                     total=len(args), 
-                                     desc=GREEN+'Clipping raw data'+ENDC, 
-                                     colour='GREEN'))
+        pool.starmap(
+            clip_func,
+            tqdm(
+                args,
+                total=len(args),
+                desc=GREEN + "Clipping raw data" + ENDC,
+                colour="GREEN",
+            ),
+        )
+
 
 def _clip_to_shape(extent, poly, col_mapper, sep, out_file, raw_file):
     print("Clipping", raw_file)
@@ -371,18 +411,19 @@ def _clip_to_shape(extent, poly, col_mapper, sep, out_file, raw_file):
     else:
         dat.columns = new_cols
         if poly:
-            #get the coords
-            coords = dat[['X','Y']].values
-            #check in
+            # get the coords
+            coords = dat[["X", "Y"]].values
+            # check in
             isin, ison = inpoly2(coords, *extent)
             mask = isin | ison
         else:
-            #get the bbox mask
+            # get the bbox mask
             xmin, ymin, xmax, ymax = extent
-            mask1 = (dat['X'] >= xmin) & (dat['X'] <= xmax)
-            mask2 = (dat['Y'] >= ymin) & (dat['Y'] <= ymax)
+            mask1 = (dat["X"] >= xmin) & (dat["X"] <= xmax)
+            mask2 = (dat["Y"] >= ymin) & (dat["Y"] <= ymax)
             mask = mask1.values & mask2.values
         dat[mask].to_csv(out_file)
+
 
 # Function to follow a chain from a starting point
 def follow_chain(start, connection_dict):
@@ -392,111 +433,131 @@ def follow_chain(start, connection_dict):
         flat_chain.append(start)  # Add the new element to the flat chain
     return flat_chain
 
-def repair_tracks_spatiotemporal(time_threshold, 
-                                 dist_threshold, 
-                                 out_path,
-                                 pkl_file):
-    #read the file
+
+def repair_tracks_spatiotemporal(
+    time_threshold, dist_threshold, out_path, pkl_file
+):
+    # read the file
     agent = utils.read_pkl(pkl_file)
-    #make a dict of startstops of each track
+    # make a dict of startstops of each track
     meta = agent.track_meta
     all_tids = meta.keys()
     connections = []
     used_tid1s = []
     used_tid2s = []
-    for i,tid1 in enumerate(all_tids):
-        for j,tid2 in enumerate(all_tids):
-            if j<=i or tid1 in used_tid1s:
+    for i, tid1 in enumerate(all_tids):
+        for j, tid2 in enumerate(all_tids):
+            if j <= i or tid1 in used_tid1s:
                 pass
             else:
-                dt = np.abs(meta[tid1]['End Time'] - meta[tid2]['Start Time']).total_seconds()
-                dx = meta[tid1]['Xend'] - meta[tid2]['Xstart']
-                dy = meta[tid1]['Yend'] - meta[tid2]['Ystart']
-                dr = (dx**2 + dy**2)**0.5
+                dt = np.abs(
+                    meta[tid1]["End Time"] - meta[tid2]["Start Time"]
+                ).total_seconds()
+                dx = meta[tid1]["Xend"] - meta[tid2]["Xstart"]
+                dy = meta[tid1]["Yend"] - meta[tid2]["Ystart"]
+                dr = (dx**2 + dy**2) ** 0.5
                 if dt <= time_threshold and dr <= dist_threshold:
-                    connections.append((tid1,tid2))
+                    connections.append((tid1, tid2))
                     used_tid1s.append(tid1)
                     used_tid2s.append(tid2)
                 else:
                     pass
-    #see if any leftover stragglers
-    all_used = list(set(used_tid1s+used_tid2s))
+    # see if any leftover stragglers
+    all_used = list(set(used_tid1s + used_tid2s))
     keep_tids = [tid for tid in all_tids if tid not in all_used]
-    #if same as before
+    # if same as before
     if len(keep_tids) == len(all_tids):
         return
     else:
-        #find unique starting points
+        # find unique starting points
         all_first_elements = {pair[0] for pair in connections}
         all_second_elements = {pair[1] for pair in connections}
         starting_points = all_first_elements - all_second_elements
-        #convert to dict
+        # convert to dict
         connection_dict = {k: v for k, v in connections}
         # Collect all chains
-        all_chains = [follow_chain(start, connection_dict) for start in starting_points]
-        #sort by time just to make sure
-        all_chains = [sorted(a,key=lambda x: meta[x]['Start Time']) for a in all_chains]
-        #create new tracks by joining chains
+        all_chains = [
+            follow_chain(start, connection_dict) for start in starting_points
+        ]
+        # sort by time just to make sure
+        all_chains = [
+            sorted(a, key=lambda x: meta[x]["Start Time"]) for a in all_chains
+        ]
+        # create new tracks by joining chains
         new_tracks = {}
-        #loop over chains
-        for i,chain in enumerate(all_chains):
-            #connect all pertinent tracks
-            tdf = pd.concat([agent.tracks[tid] for tid in chain]).sort_values(by='Time').reset_index(drop=True)
-            new_tracks[f'T{i}'] = tdf
-        #add back any stragglers
+        # loop over chains
+        for i, chain in enumerate(all_chains):
+            # connect all pertinent tracks
+            tdf = (
+                pd.concat([agent.tracks[tid] for tid in chain])
+                .sort_values(by="Time")
+                .reset_index(drop=True)
+            )
+            new_tracks[f"T{i}"] = tdf
+        # add back any stragglers
         start = len(new_tracks)
-        for i,tid in enumerate(keep_tids):
-            new_tracks[f'T{i+start}'] = agent.tracks[tid]
-        #overwrite the old tracks
+        for i, tid in enumerate(keep_tids):
+            new_tracks[f"T{i+start}"] = agent.tracks[tid]
+        # overwrite the old tracks
         agent.tracks = new_tracks
-        #overwrite the file
-        out_file = f'{out_path}/{os.path.basename(pkl_file)}'
-        agent.agent_meta['File'] = out_file
+        # overwrite the file
+        out_file = f"{out_path}/{os.path.basename(pkl_file)}"
+        agent.agent_meta["File"] = out_file
         utils.save_pkl(out_file, agent)
-    
+
+
 def get_track_gaps(pkl_file):
-    #read the file
+    # read the file
     agent = utils.read_pkl(pkl_file)
-    #init rows list
+    # init rows list
     rows = []
-    #loop over tracks, get the gaps between
+    # loop over tracks, get the gaps between
     tids = list(agent.tracks.keys())
     if len(tids) > 1:
         for tid1, tid2 in zip(tids[:-1], tids[1:]):
-            t1 = agent.tracks[tid1].iloc[-1]['Time']
-            t2 = agent.tracks[tid2].iloc[0]['Time']
-            dt = (t2-t1).total_seconds()
-            dx = agent.tracks[tid1].iloc[-1]['X'] - agent.tracks[tid2].iloc[0]['X']
-            dy = agent.tracks[tid1].iloc[-1]['Y'] - agent.tracks[tid2].iloc[0]['Y']
-            dr = (dx**2+dy**2)**0.5
-            row = {'Track ID_0': f"{agent.meta['Agent ID']}_{tid1}",
-                   'Track ID_1': f"{agent.meta['Agent ID']}_{tid2}",
-                   'Time Difference': dt,
-                   'Distance': dr,
-                   'Speed': dr/dt,
-                   'File': pkl_file,
-                   **agent.meta}
+            t1 = agent.tracks[tid1].iloc[-1]["Time"]
+            t2 = agent.tracks[tid2].iloc[0]["Time"]
+            dt = (t2 - t1).total_seconds()
+            dx = (
+                agent.tracks[tid1].iloc[-1]["X"]
+                - agent.tracks[tid2].iloc[0]["X"]
+            )
+            dy = (
+                agent.tracks[tid1].iloc[-1]["Y"]
+                - agent.tracks[tid2].iloc[0]["Y"]
+            )
+            dr = (dx**2 + dy**2) ** 0.5
+            row = {
+                "Track ID_0": f"{agent.meta['Agent ID']}_{tid1}",
+                "Track ID_1": f"{agent.meta['Agent ID']}_{tid2}",
+                "Time Difference": dt,
+                "Distance": dr,
+                "Speed": dr / dt,
+                "File": pkl_file,
+                **agent.meta,
+            }
             rows.append(row)
     return rows
 
-def remove_tracks(out_path,
-                  args):
-    #separate the args
+
+def remove_tracks(out_path, args):
+    # separate the args
     pkl_file, tracks = args
-    pkl_file = pkl_file[0] #because it comes as a list
-    #read the file
+    pkl_file = pkl_file[0]  # because it comes as a list
+    # read the file
     agent = utils.read_pkl(pkl_file)
-    #loop over tracks
+    # loop over tracks
     keys = list(agent.tracks.keys())
     for tid in keys:
         if f"{agent.meta['Agent ID']}_{tid}" in tracks:
             agent.tracks.pop(tid)
-    #if no tracks left, delete it
+    # if no tracks left, delete it
     if len(agent.tracks) == 0:
         os.remove(pkl_file)
-    #otherwise save the updated file
+    # otherwise save the updated file
     else:
-        out_file = f'{out_path}/{os.path.basename(pkl_file)}'
+        out_file = f"{out_path}/{os.path.basename(pkl_file)}"
         utils.save_pkl(out_file, agent)
-        
+
+
 ################################################################################

--- a/trackio/stats.py
+++ b/trackio/stats.py
@@ -19,7 +19,7 @@
 #     beams = pd.concat([beams,_beams])
 #     stats = beams.groupby('Type')['Width'].agg(list).apply(lambda x: pd.Series(x).describe())
 #     return stats
-   #
+#
 # def vessel_length_stats(dataset, agents=None):
 #     if agents is None:
 #         agents = dataset.agents
@@ -78,7 +78,7 @@
 #     _ds['Type'] = 'All'
 #     ds = pd.concat([ds,_ds])
 #     stats = ds.groupby('Type')['Duration'].agg(list).apply(lambda x: pd.Series(x).describe())
-#     return stats 
+#     return stats
 
 # def npings_per_vessel_stats(dataset, agents=None):
 #     if agents is None:
@@ -254,7 +254,7 @@
 #     beams = pd.concat([beams,_beams])
 #     grouped = beams.groupby('Type')['Width'].agg(list)
 #     x = grouped.apply(lambda x: np.histogram(x, bins=bins, density=False))
-#     out = pd.DataFrame({'Type':x.index, 
+#     out = pd.DataFrame({'Type':x.index,
 #                         'PDF':x.apply(lambda x: x[0]),
 #                         'Edges':x.apply(lambda x: x[1])})
 #     if density:
@@ -273,7 +273,7 @@
 #     loas = pd.concat([loas,_loas])
 #     grouped = loas.groupby('Type')['Length'].agg(list)
 #     x = grouped.apply(lambda x: np.histogram(x, bins=bins, density=False))
-#     out = pd.DataFrame({'Type':x.index, 
+#     out = pd.DataFrame({'Type':x.index,
 #                         'PDF':x.apply(lambda x: x[0]),
 #                         'Edges':x.apply(lambda x: x[1])})
 #     if density:
@@ -282,7 +282,7 @@
 #     else:
 #         pass
 #     return out
-        
+
 # def track_length_dist(dataset, bins=10, density=True):
 #     ls = dataset.tracks[['Type','Track Length']]
 #     # ls = ls[ls['Track Length'] > 0]
@@ -292,7 +292,7 @@
 #     ls = pd.concat([ls,_ls])
 #     grouped = ls.groupby('Type')['Track Length'].agg(list)
 #     x = grouped.apply(lambda x: np.histogram(x, bins=bins, density=False))
-#     out = pd.DataFrame({'Type':x.index, 
+#     out = pd.DataFrame({'Type':x.index,
 #                         'PDF':x.apply(lambda x: x[0]),
 #                         'Edges':x.apply(lambda x: x[1])})
 #     if density:
@@ -300,7 +300,7 @@
 #         out['PDF'] = out['PDF'].apply(lambda x: [y/tot for y in x])
 #     else:
 #         pass
-#     return out  
+#     return out
 
 # def track_duration_dist(dataset, bins=10, density=True):
 #     ds = dataset.tracks[['Type','Duration']]
@@ -311,7 +311,7 @@
 #     ds = pd.concat([ds,_ds])
 #     grouped = ds.groupby('Type')['Duration'].agg(list)
 #     x = grouped.apply(lambda x: np.histogram(x, bins=bins, density=False))
-#     out = pd.DataFrame({'Type':x.index, 
+#     out = pd.DataFrame({'Type':x.index,
 #                         'PDF':x.apply(lambda x: x[0]),
 #                         'Edges':x.apply(lambda x: x[1])})
 #     if density:
@@ -319,6 +319,6 @@
 #         out['PDF'] = out['PDF'].apply(lambda x: [y/tot for y in x])
 #     else:
 #         pass
-#     return out  
+#     return out
 
 # ################################################################################

--- a/trackio/utils.py
+++ b/trackio/utils.py
@@ -18,6 +18,8 @@ import pandas as pd
 import shapely
 import geopandas as gp
 
+from .Agent import Agent
+
 ################################################################################
 
 def append_pkl(out_file, pkl_obj):
@@ -45,7 +47,7 @@ def save_pkl(pkl_file, pkl_obj):
     with open(pkl_file, 'wb') as f:
         pkl.dump(pkl_obj, f)
 
-def collect_agent_pkls(pkl_files):
+def collect_agent_pkls(pkl_files) -> Agent:
     #loop over pkl files
     i = 0
     for pkl_file in pkl_files:

--- a/trackio/utils.py
+++ b/trackio/utils.py
@@ -1,31 +1,39 @@
-
 ################################################################################
 
-import pickle as pkl
-import numpy as np
-from shapely.geometry import (Polygon, 
-                              MultiPolygon, 
-                              LineString, 
-                              MultiLineString, 
-                              Point, 
-                              MultiPoint)
-from scipy.spatial import Voronoi
-from pyproj import CRS
 import multiprocessing as mp
+import pickle as pkl
 from functools import partial
-from tqdm import tqdm; GREEN = "\033[92m"; ENDC = "\033[0m" #for tqdm bar
+
+import geopandas as gp
+import numpy as np
 import pandas as pd
 import shapely
-import geopandas as gp
+from pyproj import CRS
+from scipy.spatial import Voronoi
+from shapely.geometry import (
+    LineString,
+    MultiLineString,
+    MultiPoint,
+    MultiPolygon,
+    Point,
+    Polygon,
+)
+from tqdm import tqdm
 
 from .Agent import Agent
 
+GREEN = "\033[92m"
+ENDC = "\033[0m"  # for tqdm bar
+
+
 ################################################################################
 
+
 def append_pkl(out_file, pkl_obj):
-    #appends a serialized chunk to the pickle file
+    # appends a serialized chunk to the pickle file
     with open(out_file, "ab") as p:
         pkl.dump(pkl_obj, p)
+
 
 def read_pkl(pkl_file):
     """
@@ -34,8 +42,9 @@ def read_pkl(pkl_file):
     Args:
         pkl_file (str): Path to input agent file.
     """
-    with open(pkl_file, 'rb') as f:
+    with open(pkl_file, "rb") as f:
         return pkl.load(f)
+
 
 def save_pkl(pkl_file, pkl_obj):
     """
@@ -44,30 +53,35 @@ def save_pkl(pkl_file, pkl_obj):
     Args:
         pkl_file (str): Path to output agent file.
     """
-    with open(pkl_file, 'wb') as f:
+    with open(pkl_file, "wb") as f:
         pkl.dump(pkl_obj, f)
 
+
 def collect_agent_pkls(pkl_files) -> Agent:
-    #loop over pkl files
+    # loop over pkl files
     i = 0
     for pkl_file in pkl_files:
         with open(pkl_file, "rb") as p:
-            #read until last chunk.. important!!!
+            # read until last chunk.. important!!!
             while True:
                 try:
                     _tmp = pkl.load(p)
                     if _tmp is not None:
                         if i == 0:
-                            agent = _tmp #these are pickled Agent objects
+                            agent = _tmp  # these are pickled Agent objects
                         else:
-                            agent.append_data.append(_tmp.data) #append the unsplit points
+                            agent.append_data.append(
+                                _tmp.data
+                            )  # append the unsplit points
                         i += 1
                 except EOFError:
                     break
     return agent
 
-def flatten(l):
-    return [item for sublist in l for item in sublist]
+
+def flatten(l_tmp):
+    return [item for sublist in l_tmp for item in sublist]
+
 
 def flatten_dict_unique(_out):
     out = {}
@@ -81,25 +95,31 @@ def flatten_dict_unique(_out):
         out[key] = np.unique(out[key]).tolist()
     return out
 
+
 def std_meta():
-    meta = {'X':'degrees',
-            'Y':'degrees',
-            'CRS': CRS(4326),
-            'Static Data': [],
-            'Dynamic Data': ['X','Y']}
+    meta = {
+        "X": "degrees",
+        "Y": "degrees",
+        "CRS": CRS(4326),
+        "Static Data": [],
+        "Dynamic Data": ["X", "Y"],
+    }
     return meta
+
 
 def format_input(inp, typ):
     if isinstance(inp, str):
         if typ == int:
-            numeric = ''.join([l for l in inp if l.isnumeric()])
+            numeric = "".join([l_tmp for l_tmp in inp if l_tmp.isnumeric()])
             if len(numeric) == 0:
                 inp = typ(0)
             else:
                 inp = typ(numeric)
         elif typ == float:
-            numeric = ''.join([l for l in inp if (l.isnumeric() or l == '.')])
-            if len(numeric) == 0 or all([l == '.' for l in numeric]):
+            numeric = "".join(
+                [l_tmp for l_tmp in inp if (l_tmp.isnumeric() or l_tmp == ".")]
+            )
+            if len(numeric) == 0 or all([l_tmp == "." for l_tmp in numeric]):
                 inp = typ(0)
             else:
                 inp = typ(numeric)
@@ -109,10 +129,11 @@ def format_input(inp, typ):
         inp = typ(inp)
     return inp
 
+
 def format_polygon(poly):
     if isinstance(poly, Polygon):
         poly = np.array(poly.exterior.xy).T
-        edges = [(i,i+1) for i in range(len(poly)-1)]
+        edges = [(i, i + 1) for i in range(len(poly) - 1)]
     elif isinstance(poly, MultiPolygon):
         edges = []
         polys = []
@@ -120,39 +141,51 @@ def format_polygon(poly):
         for geom in poly.geoms:
             p = geom.exterior.xy
             polys.append(np.array(p).T)
-            edges.extend([(i+j,i+j+1) for i in range(len(p[0])-1)])
+            edges.extend([(i + j, i + j + 1) for i in range(len(p[0]) - 1)])
             j += len(p[0])
         poly = np.concatenate(polys)
     elif isinstance(poly, np.ndarray):
-        edges = [(i,i+1) for i in range(len(poly)-1)]
+        edges = [(i, i + 1) for i in range(len(poly) - 1)]
         pass
     else:
-        raise Exception('Polygon must be shapely polygon or 2D numpy array of polygon exterior')
+        raise Exception(
+            "Polygon must be shapely polygon or 2D numpy array of polygon exterior"
+        )
     return poly, edges
 
+
 def pool_caller(func, partials, iterable, desc, ncores):
-    #join func and kwargs
+    # join func and kwargs
     map_func = partial(func, *partials)
-    #if only 1 core
+    # if only 1 core
     out = []
     if ncores == 1:
-        for i in tqdm(iterable, total=len(iterable), desc=GREEN+desc+ENDC, colour='GREEN'):
+        for i in tqdm(
+            iterable,
+            total=len(iterable),
+            desc=GREEN + desc + ENDC,
+            colour="GREEN",
+        ):
             out.append(map_func(i))
-    #if in parallel
+    # if in parallel
     else:
         with mp.Pool(ncores) as pool:
-            out = pool.map(map_func, 
-                        tqdm(iterable, 
-                             total=len(iterable), 
-                             desc=GREEN+desc+ENDC,
-                             colour='GREEN'))
+            out = pool.map(
+                map_func,
+                tqdm(
+                    iterable,
+                    total=len(iterable),
+                    desc=GREEN + desc + ENDC,
+                    colour="GREEN",
+                ),
+            )
     return out
 
+
 def prepare_polylines(shape):
-    #convert shape into set of polylines
+    # convert shape into set of polylines
     polylines = []
-    if isinstance(shape, (MultiLineString, 
-                        MultiPolygon, MultiPoint)):
+    if isinstance(shape, (MultiLineString, MultiPolygon, MultiPoint)):
         for geom in shape.geoms:
             if isinstance(geom, (LineString, Point)):
                 polylines.append(np.array(geom.xy).T)
@@ -161,120 +194,123 @@ def prepare_polylines(shape):
     else:
         if isinstance(shape, (LineString, Point)):
             polylines.append(np.array(shape.xy).T)
-        else: #Polygon
+        else:  # Polygon
             polylines.append(np.array(shape.exterior.xy).T)
     return polylines
 
+
 def split_list(lst, n):
     # Using list comprehension to generate chunks
-    return [lst[i:i + n] for i in range(0, len(lst), n)]
+    return [lst[i : i + n] for i in range(0, len(lst), n)]
+
 
 def gdf_to_df(gdf):
-    #prep it into a dataframe
+    # prep it into a dataframe
     rows = []
     for i in range(len(gdf)):
-        #get master row
+        # get master row
         _row = gdf.iloc[i].to_dict()
-        #track coords
-        x, y = _row['geometry'].xy
-        #dummy times, 1 second, all overlapping
-        times = pd.date_range(0,1e9, periods=len(x))
-        for x,y,t in zip(x, y, times):
+        # track coords
+        x, y = _row["geometry"].xy
+        # dummy times, 1 second, all overlapping
+        times = pd.date_range(0, 1e9, periods=len(x))
+        for x, y, t in zip(x, y, times):
             row = _row.copy()
-            row['Time'] = t
-            row['X'] = x
-            row['Y'] = y
+            row["Time"] = t
+            row["X"] = x
+            row["Y"] = y
             rows.append(row)
     return pd.DataFrame(rows)
 
-def longitudinal_slices(start, 
-                        end, 
-                        n_slices, 
-                        spacing, 
-                        dist):
-    #if n_slices instead of spacing
+
+def longitudinal_slices(start, end, n_slices, spacing, dist):
+    # if n_slices instead of spacing
     if n_slices > 0:
         if n_slices == 1:
-            #make longitudinal slices
+            # make longitudinal slices
             long = np.array([0])
         else:
-            #make longitudinal slices
+            # make longitudinal slices
             long = np.linspace(0, dist, n_slices)
-    #if spacing
+    # if spacing
     else:
-        #make longitudinal slices
-        long = np.concatenate([np.arange(0, 
-                                        dist, 
-                                        spacing), 
-                            [dist]])
-    #turn into coordinates
+        # make longitudinal slices
+        long = np.concatenate([np.arange(0, dist, spacing), [dist]])
+    # turn into coordinates
     xy = []
     for i in range(len(long)):
-        dx = (end[0]-start[0]) * long[i]/dist
-        dy = (end[1]-start[1]) * long[i]/dist
-        xy.append((start[0]+dx, start[1]+dy))
+        dx = (end[0] - start[0]) * long[i] / dist
+        dy = (end[1] - start[1]) * long[i] / dist
+        xy.append((start[0] + dx, start[1] + dy))
     xy = np.array(xy)
     return long, xy
 
+
 def range_to_edges(global_min, global_max, bins):
-    #all entries the same
+    # all entries the same
     if global_min == global_max:
-        edges = np.array([global_min, global_min+bins])
-    #distribution of entries
+        edges = np.array([global_min, global_min + bins])
+    # distribution of entries
     else:
-        #if both +/-
+        # if both +/-
         if np.sign(global_min) == np.sign(global_max):
             sign = np.sign(global_min)
-            abs_max = np.abs([global_min, global_max]).max() 
-            edges = np.sort(np.arange(0, abs_max+bins, bins)*sign)
-        #if + and -  
+            abs_max = np.abs([global_min, global_max]).max()
+            edges = np.sort(np.arange(0, abs_max + bins, bins) * sign)
+        # if + and -
         else:
-            edges1 = np.arange(0, global_max+bins, bins)
-            edges2 = -np.arange(0, np.abs(global_min)+bins, bins)
+            edges1 = np.arange(0, global_max + bins, bins)
+            edges2 = -np.arange(0, np.abs(global_min) + bins, bins)
             edges = np.sort(np.unique(np.concatenate([edges1, edges2])))
     return edges
 
+
 def first_nonzero(lst):
     out = 0
-    for l in lst:
-        if l != 0:
-            out = l
+    for l_tmp in lst:
+        if l_tmp != 0:
+            out = l_tmp
             break
     return out
-                
+
+
 def NN_idx2(query, coords):
-    dx = coords[:,:,0] - query[0]    
-    dy = coords[:,:,1] - query[1]
-    dr = dx**2 + dy**2        
+    dx = coords[:, :, 0] - query[0]
+    dy = coords[:, :, 1] - query[1]
+    dr = dx**2 + dy**2
     idx2 = np.unravel_index(np.argmin(dr), dr.shape)
     return idx2
 
+
 def create_voronoi(centroids, buffer=500000):
-    #make buffer points
-    centroid = Point(centroids[['X','Y']].values.mean(axis=0))
-    buffer_pts = np.array(centroid.buffer(buffer, resolution=1000).exterior.xy).T
-    #combine centroids + buffer points
-    pts = np.vstack([centroids[['X','Y']].values, buffer_pts])
-    #make voronoi diagram
+    # make buffer points
+    centroid = Point(centroids[["X", "Y"]].values.mean(axis=0))
+    buffer_pts = np.array(
+        centroid.buffer(buffer, resolution=1000).exterior.xy
+    ).T
+    # combine centroids + buffer points
+    pts = np.vstack([centroids[["X", "Y"]].values, buffer_pts])
+    # make voronoi diagram
     vor = Voronoi(pts)
-    #convert to poylgons
+    # convert to poylgons
     lines = [
         LineString(vor.vertices[line])
         for line in vor.ridge_vertices
         if -1 not in line
     ]
     polys = list(shapely.ops.polygonize(lines))
-    #convert to geodataframe, clip to domain extent
+    # convert to geodataframe, clip to domain extent
     voronoi = gp.GeoDataFrame(geometry=polys, crs=centroids.crs)
-    #add centroids to dataframe
-    voronoi['Code'] = np.array(list(range(len(voronoi))))+1
-    voronoi['X'] = np.nan
-    voronoi['Y'] = np.nan
+    # add centroids to dataframe
+    voronoi["Code"] = np.array(list(range(len(voronoi)))) + 1
+    voronoi["X"] = np.nan
+    voronoi["Y"] = np.nan
     for i in range(len(voronoi)):
         for p in centroids.geometry:
             if voronoi.geometry.iloc[i].intersects(p):
-                voronoi.iat[i, voronoi.columns.get_loc('X')] = p.x
-                voronoi.iat[i, voronoi.columns.get_loc('Y')] = p.y
+                voronoi.iat[i, voronoi.columns.get_loc("X")] = p.x
+                voronoi.iat[i, voronoi.columns.get_loc("Y")] = p.y
     return voronoi
+
 
 ################################################################################

--- a/trackio/utils.py
+++ b/trackio/utils.py
@@ -8,6 +8,8 @@ import geopandas as gp
 import numpy as np
 import pandas as pd
 import shapely
+from geopandas import GeoDataFrame, points_from_xy
+from pandas import DataFrame
 from pyproj import CRS
 from scipy.spatial import Voronoi
 from shapely.geometry import (
@@ -221,6 +223,25 @@ def gdf_to_df(gdf):
             row["Y"] = y
             rows.append(row)
     return pd.DataFrame(rows)
+
+
+def df_to_gdf(
+    df: DataFrame, x_dimension: str, y_dimension: str, crs: str
+) -> GeoDataFrame:
+    """Converts a DataFrame to a GeoDataFrame. The "geometry" column is appended after the last column.
+
+    Args:
+        df (DataFrame): Pandas DataFrame.
+        x_dimension (str): Name of the x-coordinate column in the DataFrame.
+        y_dimension (str): Name of the y-coordinate column in the DataFrame.
+        crs (str): Coordinate reference system.
+
+    Returns:
+        GeoDataFrame: Georeferenced DataFrame.
+    """
+    return GeoDataFrame(
+        df, geometry=points_from_xy(df[x_dimension], df[y_dimension]), crs=crs
+    )
 
 
 def longitudinal_slices(start, end, n_slices, spacing, dist):


### PR DESCRIPTION
Added the "sep" statement to various read_csv functions (also parent functions and some partials) in the trackio. This allows to read csv files that are differently seperated than with "," (which is e.g. quite common in Germany).
Alternative would have been to just set sep=None as a default, which lets the pands read_csv function automatically detect the separator. This, however, only works with the python engine of the csv reader, which is slower than the default c engine.

So I decided to use sep=',' as the default, and the user can pass another delimiter when wished. 